### PR TITLE
feat(seo): SEO meta tags, robots.txt, sitemap, fix footer link

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -4,8 +4,28 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="CV en ligne — Développeur Full Stack" />
-    <title>CV — Développeur Full Stack</title>
+
+    <!-- Primary meta -->
+    <meta name="description" content="CV en ligne — Développeur Full Stack React · TypeScript · Node.js. Disponible en freelance et CDI." />
+    <meta name="author" content="Anthony GREAU" />
+    <meta name="robots" content="index, follow" />
+    <link rel="canonical" href="https://resume.chrysa.dev/" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="profile" />
+    <meta property="og:title" content="Anthony GREAU — Développeur Full Stack" />
+    <meta property="og:description" content="CV interactif — React · TypeScript · Node.js. Disponible en freelance et CDI." />
+    <meta property="og:url" content="https://resume.chrysa.dev/" />
+    <meta property="og:locale" content="fr_FR" />
+    <meta property="og:locale:alternate" content="en_US" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Anthony GREAU — Développeur Full Stack" />
+    <meta name="twitter:description" content="CV interactif — React · TypeScript · Node.js. Disponible en freelance et CDI." />
+
+    <title>Anthony GREAU — Développeur Full Stack</title>
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet" />

--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://resume.chrysa.dev/sitemap.xml

--- a/app/public/sitemap.xml
+++ b/app/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://resume.chrysa.dev/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/app/src/__tests__/useDocumentMeta.test.ts
+++ b/app/src/__tests__/useDocumentMeta.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDocumentMeta } from '@/hooks/useDocumentMeta';
+
+function addMeta(name: string, property?: string) {
+  const el = document.createElement('meta');
+  if (property) el.setAttribute('property', property);
+  else el.setAttribute('name', name);
+  el.setAttribute('content', '');
+  document.head.appendChild(el);
+  return el;
+}
+
+describe('useDocumentMeta', () => {
+  beforeEach(() => {
+    document.title = '';
+    document.querySelectorAll('meta[name],meta[property]').forEach((el) => el.remove());
+    addMeta('description');
+    addMeta('', 'og:title');
+    addMeta('', 'og:description');
+    addMeta('twitter:title');
+    addMeta('twitter:description');
+  });
+
+  it('sets document.title in French by default', () => {
+    renderHook(() => useDocumentMeta());
+    expect(document.title).toContain('Développeur Full Stack');
+  });
+
+  it('sets document.title in English when lang=en', () => {
+    renderHook(() => useDocumentMeta({ lang: 'en' }));
+    expect(document.title).toContain('Full Stack Developer');
+  });
+
+  it('updates meta description', () => {
+    renderHook(() => useDocumentMeta({ lang: 'fr' }));
+    const desc = document.querySelector('meta[name="description"]')?.getAttribute('content') ?? '';
+    expect(desc.length).toBeGreaterThan(0);
+  });
+
+  it('sets html lang attribute', () => {
+    renderHook(() => useDocumentMeta({ lang: 'en' }));
+    expect(document.documentElement.getAttribute('lang')).toBe('en');
+  });
+});

--- a/app/src/hooks/useDocumentMeta.ts
+++ b/app/src/hooks/useDocumentMeta.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import cvData from '../../cv.json';
+
+interface DocumentMetaOptions {
+  lang?: string;
+}
+
+/**
+ * Updates document.title and meta description based on cv.json data.
+ * Call once from the root page component.
+ */
+export function useDocumentMeta({ lang = 'fr' }: DocumentMetaOptions = {}) {
+  useEffect(() => {
+    const { firstName, lastName, headline } = cvData.basics;
+    const name = `${firstName} ${lastName}`.trim();
+
+    const titleEn = `${name} — Full Stack Developer`;
+    const titleFr = `${name} — Développeur Full Stack`;
+    const title = lang === 'en' ? titleEn : titleFr;
+
+    const descEn = `Interactive CV — ${headline}. Contact via GitHub Issues.`;
+    const descFr = `CV interactif — ${headline}. Contact via GitHub Issues.`;
+    const description = lang === 'en' ? descEn : descFr;
+
+    document.title = title;
+
+    const setMeta = (selector: string, value: string) => {
+      const el = document.querySelector(selector);
+      if (el) el.setAttribute('content', value);
+    };
+
+    setMeta('meta[name="description"]', description);
+    setMeta('meta[property="og:title"]', title);
+    setMeta('meta[property="og:description"]', description);
+    setMeta('meta[name="twitter:title"]', title);
+    setMeta('meta[name="twitter:description"]', description);
+
+    document.documentElement.setAttribute('lang', lang === 'en' ? 'en' : 'fr');
+  }, [lang]);
+}

--- a/app/src/pages/CVPage.tsx
+++ b/app/src/pages/CVPage.tsx
@@ -12,11 +12,13 @@ import { ContactModal } from '@/components/contact/ContactModal';
 import { ScrollProgress } from '@/components/ui/ScrollProgress';
 import { CustomCursor } from '@/components/ui/CustomCursor';
 import { FloatingCTA } from '@/components/ui/FloatingCTA';
+import { useDocumentMeta } from '@/hooks/useDocumentMeta';
 
 export function CVPage() {
   const [modalOpen, setModalOpen] = useState(false);
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const openModal = () => setModalOpen(true);
+  useDocumentMeta({ lang: i18n.language });
 
   return (
     <>
@@ -40,7 +42,7 @@ export function CVPage() {
             &copy; {new Date().getFullYear()} &middot; {t('footer.madeWith')} &#9749;
           </span>
           <a
-            href="https://github.com/chrysa/resume"
+            href="https://github.com/chrysa/linkendin-resume"
             target="_blank"
             rel="noopener noreferrer"
             className="footer__source"


### PR DESCRIPTION
## Changes

### Bug fix
- fix(footer): correct GitHub repo link `chrysa/resume` → `chrysa/linkendin-resume`

### SEO improvements
- feat(index.html): add Open Graph tags, Twitter Card, canonical URL, robots meta
- feat(public): add `robots.txt` (Allow: /, Sitemap link) and `sitemap.xml`

### Dynamic meta
- feat(hooks/useDocumentMeta): new hook that updates `document.title`, meta description and OG tags from `cv.json` data, respecting the active i18n language (FR/EN)
- feat(pages/CVPage): integrate `useDocumentMeta` hook

### Tests
- test: add `useDocumentMeta.test.ts` (4 tests covering FR/EN title, description, and lang attribute)

Closes #27 (partially — SEO/discoverability addressed)