### PR TITLE
ci(pre-commit): bump chrysa/pre-commit-tools to v0.1.1-72

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/chrysa/pre-commit-tools
-    rev: v0.1.1-67
+    rev: v0.1.1-72
     hooks:
       - id: console-debug-detection
         files: '\.(js|gs|ts|tsx|jsx)$'


### PR DESCRIPTION
Bump `chrysa/pre-commit-tools` to `v0.1.1-72` — fixes Python 3.14 compatibility (`setuptools.backends.legacy` unavailable error).