### PR TITLE
ci(pre-commit): bump chrysa/pre-commit-tools to v0.1.1-73

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/chrysa/pre-commit-tools
-    rev: v0.1.1-72
+    rev: v0.1.1-73
     hooks:
       - id: console-debug-detection
         files: '\.(js|gs|ts|tsx|jsx)$'


### PR DESCRIPTION
Bump to v0.1.1-73. New: adr-gate hook (chrysa/pre-commit-tools#135).