### PR TITLE
fix(ci): pass github.ref_name through env var to prevent script injection

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,9 +43,10 @@ jobs:
               if: startsWith(github.ref, 'refs/tags/v')
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  REF_NAME: ${{ github.ref_name }}
               run: |
-                  gh release create "${{ github.ref_name }}" \
-                      --title "Release ${{ github.ref_name }}" \
+                  gh release create "$REF_NAME" \
+                      --title "Release $REF_NAME" \
                       --generate-notes
               shell: bash
 


### PR DESCRIPTION
Fixes actionlint SC2086 / script injection: `${{ github.ref_name }}` is now passed via `env: REF_NAME:` instead of being interpolated directly in the `run:` shell script.