### PR TITLE
ci: migrate to chrysa/github-actions composite actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,189 +2,173 @@
 name: CI
 
 on:
-    push:
-        branches:
-            - main
-            - develop
-            - "feat/**"
-            - "fix/**"
-            - "ci/**"
-            - "chore/**"
-    pull_request:
-        branches: [main, develop]
-    workflow_dispatch:
+  push:
+    branches:
+      - main
+      - develop
+      - "feat/**"
+      - "fix/**"
+      - "ci/**"
+      - "chore/**"
+  pull_request:
+    branches: [main, develop]
+  workflow_dispatch:
 
 permissions:
-    contents: read
+  contents: read
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-    pre-commit:
-        name: Pre-commit checks
-        runs-on: ubuntu-latest
-        timeout-minutes: 15
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-            - name: Setup Python
-              uses: actions/setup-python@v6.2.0
-              with:
-                  python-version: '3.14'
-            - name: Install pre-commit
-              run: pip install --quiet pre-commit
-              shell: bash
-            - name: Run pre-commit
-              run: pre-commit run --all-files --show-diff-on-failure
-              shell: bash
+  pre-commit:
+    name: Pre-commit checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.14"
+      - name: Install pre-commit
+        run: pip install --quiet pre-commit
+        shell: bash
+      - name: Run pre-commit
+        run: pre-commit run --all-files --show-diff-on-failure
+        shell: bash
 
-    version:
-        name: Compute version (GitVersion)
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        outputs:
-            semver: ${{ steps.gitversion.outputs.fullSemVer }}
-            major: ${{ steps.gitversion.outputs.major }}
-            minor: ${{ steps.gitversion.outputs.minor }}
-            patch: ${{ steps.gitversion.outputs.patch }}
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-            - name: Compute version
-              id: gitversion
-              uses: chrysa/github-actions/gitversion@v1
-            - name: Show version
-              run: echo "Version ${{ steps.gitversion.outputs.fullSemVer }}"
-              shell: bash
+  version:
+    name: Compute version (GitVersion)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      semver: ${{ steps.gitversion.outputs.fullSemVer }}
+      major: ${{ steps.gitversion.outputs.major }}
+      minor: ${{ steps.gitversion.outputs.minor }}
+      patch: ${{ steps.gitversion.outputs.patch }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Compute version
+        id: gitversion
+        uses: chrysa/github-actions/gitversion@v1
+      - name: Show version
+        run: echo "Version ${{ steps.gitversion.outputs.fullSemVer }}"
+        shell: bash
 
-    lint:
-        name: Lint & Type Check
-        runs-on: ubuntu-latest
-        timeout-minutes: 15
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-            - name: Setup Node.js
-              uses: actions/setup-node@v6.4.0
-              with:
-                  node-version: '24'
-                  cache: npm
-                  cache-dependency-path: app/package-lock.json
-            - name: Install dependencies
-              run: npm ci
-              working-directory: app
-              shell: bash
-            - name: ESLint
-              run: npm run lint
-              working-directory: app
-              shell: bash
-            - name: TypeScript type check
-              run: npm run type-check
-              working-directory: app
-              shell: bash
+  lint:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: app
+        shell: bash
+      - name: ESLint
+        run: npm run lint
+        working-directory: app
+        shell: bash
+      - name: TypeScript type check
+        run: npm run type-check
+        working-directory: app
+        shell: bash
 
-    test:
-        name: Unit Tests + Coverage
-        runs-on: ubuntu-latest
-        timeout-minutes: 15
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-            - name: Setup Node.js
-              uses: actions/setup-node@v6.4.0
-              with:
-                  node-version: '24'
-                  cache: npm
-                  cache-dependency-path: app/package-lock.json
-            - name: Install dependencies
-              run: npm ci
-              working-directory: app
-              shell: bash
-            - name: Run tests with coverage
-              run: npm run test:coverage
-              working-directory: app
-              shell: bash
-            - name: Upload coverage report
-              uses: actions/upload-artifact@v7
-              if: always()
-              with:
-                  name: coverage-report
-                  path: app/coverage/
-                  retention-days: 14
+  test:
+    name: Unit Tests + Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: app
+        shell: bash
+      - name: Run tests with coverage
+        run: npm run test:coverage
+        working-directory: app
+        shell: bash
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: coverage-lcov
+          path: app/coverage/
+          retention-days: 14
 
-    build:
-        name: Build
-        runs-on: ubuntu-latest
-        timeout-minutes: 15
-        needs:
-            - lint
-            - test
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-            - name: Setup Node.js
-              uses: actions/setup-node@v6.4.0
-              with:
-                  node-version: '24'
-                  cache: npm
-                  cache-dependency-path: app/package-lock.json
-            - name: Install dependencies
-              run: npm ci
-              working-directory: app
-              shell: bash
-            - name: Build
-              run: npm run build
-              working-directory: app
-              shell: bash
-            - name: Upload dist artifact
-              uses: actions/upload-artifact@v7
-              with:
-                  name: dist
-                  path: app/dist/
-                  retention-days: 1
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - lint
+      - test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: app
+        shell: bash
+      - name: Build
+        run: npm run build
+        working-directory: app
+        shell: bash
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist
+          path: app/dist/
+          retention-days: 1
 
-    sonar:
-        name: SonarCloud Analysis
-        runs-on: ubuntu-latest
-        timeout-minutes: 15
-        needs:
-            - test
-        permissions:
-            contents: read
-            pull-requests: read
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-              with:
-                  fetch-depth: 0
-            - name: Download coverage report
-              uses: actions/download-artifact@v8
-              with:
-                  name: coverage-report
-                  path: app/coverage/
-              continue-on-error: true
-            - name: SonarCloud Scan
-              if: github.actor != 'dependabot[bot]'
-              uses: SonarSource/sonarqube-scan-action@v8.0.0
-              with:
-                  projectBaseDir: app
-                  args: >
-                      -Dsonar.projectKey=chrysa_linkendin-resume
-                      -Dsonar.organization=chrysa
-                      -Dsonar.projectName=linkendin-resume
-                      -Dsonar.sourceEncoding=UTF-8
-                      -Dsonar.sources=src
-                      -Dsonar.tests=src
-                      -Dsonar.test.inclusions=src/**/*.test.ts,src/**/*.test.tsx,src/**/__tests__/**
-                      -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
-                      -Dsonar.exclusions=**/node_modules/**,**/dist/**,**/coverage/**
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-            - name: SonarCloud skipped
-              if: github.actor == 'dependabot[bot]'
-              run: echo "Skipping SonarCloud scan for Dependabot pull requests."
+  sonar:
+    name: SonarCloud Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs:
+      - test
+    if: github.actor != 'dependabot[bot]'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: SonarCloud Scan
+        uses: chrysa/github-actions/sonar-scan-node@v1
+        with:
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          project-key: chrysa_linkendin-resume
+          organization: chrysa
+          project-name: linkendin-resume
+          sources: app/src
+          tsconfig: app/tsconfig.json

--- a/.github/workflows/enforce-feature-branch.yml
+++ b/.github/workflows/enforce-feature-branch.yml
@@ -1,3 +1,4 @@
+---
 name: Enforce Feature Branch Policy
 
 on:
@@ -5,18 +6,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  branch-policy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate PR source branch naming
-        shell: bash
-        run: |
-          branch="${BRANCH_NAME}"
-          pattern='^(feature|fix|chore|docs|refactor|test|ci|build|perf|hotfix)/[a-z0-9._-]+$'
-          if [[ ! "$branch" =~ $pattern ]]; then
-            echo "Invalid branch name: $branch"
-            echo "Expected: type/short-description (e.g. feature/add-auth-flow)"
-            exit 1
-          fi
-        env:
-          BRANCH_NAME: ${{ github.head_ref }}
+  call:
+    uses: chrysa/github-actions/.github/workflows/enforce-feature-branch.yml@main
+    secrets: inherit

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -16,20 +16,18 @@ jobs:
         name: SonarCloud scan
         runs-on: ubuntu-latest
         timeout-minutes: 15
+        if: github.actor != 'dependabot[bot]'
         steps:
             - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - name: SonarCloud scan
-              uses: SonarSource/sonarqube-scan-action@v8.0.0
+            - name: SonarCloud Scan
+              uses: chrysa/github-actions/sonar-scan-node@v1
               with:
-                  args: >
-                      -Dsonar.projectKey=chrysa_linkendin-resume
-                      -Dsonar.organization=chrysa
-                      -Dsonar.projectName=linkendin-resume
-                      -Dsonar.sources=.
-                      -Dsonar.exclusions=**/.git/**,**/reports/**,**/.vscode/**,**/node_modules/**
-                      -Dsonar.sourceEncoding=UTF-8
-              env:
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+                  sonar-token: ${{ secrets.SONAR_TOKEN }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  project-key: chrysa_linkendin-resume
+                  organization: chrysa
+                  project-name: linkendin-resume
+                  sources: app/src
+                  tsconfig: app/tsconfig.json


### PR DESCRIPTION
## What

Migrate inline GitHub Actions steps to reusable patterns from `chrysa/github-actions`.

## Changes

| Workflow | Before | After |
|---|---|---|
| `enforce-feature-branch.yml` | Inline bash regex script | `uses: chrysa/github-actions/.github/workflows/enforce-feature-branch.yml@main` |
| `ci.yml` sonar job | Inline `SonarSource/sonarqube-scan-action@v8` with hardcoded args | `chrysa/github-actions/sonar-scan-node@v1` composite |
| `ci.yml` test job | Artifact named `coverage-report` | Renamed to `coverage-lcov` (matches composite expectation) |
| `sonar.yml` | Inline scan with `sonar.sources=.` (wrong) | `sonar-scan-node@v1` with `sources: app/src` (correct) |

## Notes
- `sonar.yml` also gains a dependabot skip guard at job level
- `cd.yml` not migrated — its release pattern (gh release + generate-notes) differs from the reusable release.yml (git-cliff)