### PR TITLE
fix(quality): add Dockerfile.test, docker-test target, coverage thresholds

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,9 @@
+FROM node:24-alpine3.21 AS deps
+WORKDIR /app
+COPY app/package.json app/package-lock.json app/.npmrc ./
+RUN npm ci
+
+FROM deps AS test
+COPY app/ .
+ENV PATH=/app/node_modules/.bin:$PATH
+CMD ["npm", "run", "test:coverage"]

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
       tempDir: '/tmp/vitest-coverage-tmp',
       include: ['src/**/*.{ts,tsx}'],
       exclude: ['src/__tests__/**', 'src/types/**', 'src/vite-env.d.ts', '**/*.d.ts'],
+      thresholds: {
+        lines: 65,
+        branches: 50,
+        functions: 55,
+        statements: 65,
+      },
     },
   },
   resolve: {

--- a/makefiles/tests.Makefile
+++ b/makefiles/tests.Makefile
@@ -3,6 +3,10 @@ test: ensure-container ## Run unit tests
 	$(call npm_simple,test)
 	@echo "$(COLOR_GREEN)✓ Tests passed$(COLOR_RESET)"
 
+docker-test: ## Run tests inside Docker (CI-compatible, no docker-compose needed)
+	docker build -f Dockerfile.test -t linkendin-resume-test .
+	docker run --rm linkendin-resume-test
+
 test-watch: ensure-container ## Run tests in watch mode
 	$(call npm_simple,test:watch)
 


### PR DESCRIPTION
## Changes

- Add `Dockerfile.test` (Node 24 alpine)
- Add `docker-test` Makefile target in `makefiles/tests.Makefile`
- Add coverage thresholds in `app/vitest.config.ts` (lines 65%, branches 50%, functions 55%, statements 65%)

## Test Results

- 116 tests passed across 12 files ✅
- Baseline thresholds set to current coverage level (no regression)