### PR TITLE
fix(sonar): S6759 readonly props, S7764 window→globalThis, S7780 String.raw

### DIFF
--- a/app/src/components/contact/ContactModal.tsx
+++ b/app/src/components/contact/ContactModal.tsx
@@ -14,8 +14,8 @@ const schema = z.object({
 type FormErrors = Partial<Record<keyof ContactFormData, string>>;
 
 interface ContactModalProps {
-  isOpen: boolean;
-  onClose: () => void;
+  readonly isOpen: boolean;
+  readonly onClose: () => void;
 }
 
 type Status = 'idle' | 'loading' | 'success' | 'error';

--- a/app/src/components/cv/ImpactMetrics.tsx
+++ b/app/src/components/cv/ImpactMetrics.tsx
@@ -5,7 +5,7 @@ import { getMetrics } from '@/data/profile';
 import { useCountUp } from '@/hooks/useCountUp';
 import { stagger, scaleIn } from '@/utils/animations';
 
-function MetricCard({ value, label, sublabel }: { value: string; label: string; sublabel?: string }) {
+function MetricCard({ value, label, sublabel }: { readonly value: string; readonly label: string; readonly sublabel?: string }) {
   const { ref, display } = useCountUp(value);
   return (
     <motion.div

--- a/app/src/components/ui/CommandPalette.tsx
+++ b/app/src/components/ui/CommandPalette.tsx
@@ -12,7 +12,7 @@ interface PaletteAction {
 }
 
 interface CommandPaletteProps {
-  onContactClick: () => void;
+  readonly onContactClick: () => void;
 }
 
 export function CommandPalette({ onContactClick }: CommandPaletteProps) {
@@ -97,7 +97,7 @@ export function CommandPalette({ onContactClick }: CommandPaletteProps) {
         label: t('palette.print'),
         icon: 'bi-printer',
         group: t('palette.groupActions'),
-        action: () => window.print(),
+        action: () => globalThis.print(),
         keywords: 'pdf print télécharger download',
       },
       // Appearance
@@ -175,8 +175,8 @@ export function CommandPalette({ onContactClick }: CommandPaletteProps) {
         setOpen(false);
       }
     };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
+    globalThis.addEventListener('keydown', handler);
+    return () => globalThis.removeEventListener('keydown', handler);
   }, [open]);
 
   useEffect(() => {

--- a/app/src/components/ui/FloatingCTA.tsx
+++ b/app/src/components/ui/FloatingCTA.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 
-export function FloatingCTA({ onContactClick }: { onContactClick: () => void }) {
+export function FloatingCTA({ onContactClick }: { readonly onContactClick: () => void }) {
   const { t } = useTranslation();
   const [visible, setVisible] = useState(false);
 

--- a/app/src/components/ui/TerminalEasterEgg.tsx
+++ b/app/src/components/ui/TerminalEasterEgg.tsx
@@ -16,8 +16,8 @@ function renderLine(content: string) {
   // Using dynamic RegExp to avoid no-control-regex linting for ESC (\x1b)
   const esc = '\x1b';
   return content
-    .replace(new RegExp(`${esc}\\[33m(.*?)${esc}\\[0m`, 'g'), '<span style="color:#f59e0b">$1</span>')
-    .replace(new RegExp(`${esc}\\[36m(.*?)${esc}\\[0m`, 'g'), '<span style="color:#06b6d4">$1</span>');
+    .replace(new RegExp(String.raw`${esc}\[33m(.*?)${esc}\[0m`, 'g'), '<span style="color:#f59e0b">$1</span>')
+    .replace(new RegExp(String.raw`${esc}\[36m(.*?)${esc}\[0m`, 'g'), '<span style="color:#06b6d4">$1</span>');
 }
 
 function buildCommands(lang: string) {
@@ -104,8 +104,8 @@ export function TerminalEasterEgg() {
       }
       if (e.key === 'Escape' && open) setOpen(false);
     };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
+    globalThis.addEventListener('keydown', handler);
+    return () => globalThis.removeEventListener('keydown', handler);
   }, [open]);
 
   useEffect(() => {

--- a/app/src/contexts/ProfileContext.tsx
+++ b/app/src/contexts/ProfileContext.tsx
@@ -19,9 +19,9 @@ export function useProfile(): CvProfile {
  *   /?profile=backend    → profil Backend
  *   /                    → profil default (CV complet)
  */
-export function ProfileProvider({ children }: { children: React.ReactNode }) {
+export function ProfileProvider({ children }: { readonly children: React.ReactNode }) {
   const profile = useMemo(() => {
-    const slug = new URLSearchParams(window.location.search).get('profile') ?? 'default';
+    const slug = new URLSearchParams(globalThis.location.search).get('profile') ?? 'default';
     return PROFILES[slug] ?? DEFAULT_PROFILE;
   }, []);
 

--- a/app/src/hooks/useTheme.tsx
+++ b/app/src/hooks/useTheme.tsx
@@ -12,11 +12,11 @@ const ThemeContext = createContext<ThemeContextValue>({
   toggle: () => {},
 });
 
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
+export function ThemeProvider({ children }: { readonly children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>(() => {
     const saved = localStorage.getItem('theme') as Theme | null;
     if (saved === 'light' || saved === 'dark') return saved;
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    return globalThis.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Fixes 15 remaining SonarCloud issues in linkendin-resume.

### Changes

**S6759 (6x) — Mark props as readonly**
- `CommandPalette.tsx`: `CommandPaletteProps.onContactClick` readonly
- `ContactModal.tsx`: `ContactModalProps.isOpen` + `.onClose` readonly
- `ImpactMetrics.tsx`: `MetricCard` inline props all readonly
- `FloatingCTA.tsx`: `onContactClick` inline prop readonly
- `ProfileContext.tsx`: `children` prop readonly
- `useTheme.tsx`: `children` prop readonly

**S7764 (7x) — `window.` → `globalThis.`**
- `CommandPalette.tsx`: `window.print()`, `window.addEventListener/removeEventListener`
- `TerminalEasterEgg.tsx`: `window.addEventListener/removeEventListener`
- `ProfileContext.tsx`: `window.location.search`
- `useTheme.tsx`: `window.matchMedia`

**S7780 (2x) — Use `String.raw` in regex template literals**
- `TerminalEasterEgg.tsx`: both ANSI color regex patterns

Note: S3776 + S6819 appear stale in SonarCloud (already fixed in commit 42308b4).