### PR TITLE
chore(pre-commit): add missing chrysa hooks from standards audit

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,17 @@
+# DECISIONS — linkendin-resume
+
+> Repository-local ADRs (Architectural Decision Records). Numbering: D-XXXX.
+> Any deviation from [CODE_MANIFEST.md](../../shared-standards/CODE_MANIFEST.md) must be documented here.
+> No active deviation → this project follows all chrysa global standards.
+
+---
+
+## D-0001 — Adherence to chrysa global standards
+
+**Date**: 2026-05-25
+**Status**: accepted
+
+This project follows all conventions defined in `CODE_MANIFEST.md` (chrysa portfolio standards).
+No active deviation is in effect. Any future deviation must be added as a new ADR entry below.
+
+---


### PR DESCRIPTION
Part of ecosystem-wide standards audit. Adds missing chrysa/pre-commit-tools hooks based on repo stack detection.

Related: chrysa/pre-commit-tools#168 chrysa/pre-commit-tools#169 chrysa/pre-commit-tools#170 chrysa/pre-commit-tools#171 chrysa/pre-commit-tools#172 chrysa/pre-commit-tools#173