### PR TITLE
fix(claude): wrap PreCompact/Notification hooks in hooks array

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,9 +5,13 @@
   "hooks": {
     "PreCompact": [
       {
-        "type": "command",
-        "command": "~/.claude/hooks/pre-compact.sh",
-        "timeout": 5000
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/pre-compact.sh",
+            "timeout": 5000
+          }
+        ]
       }
     ],
     "PreToolUse": [
@@ -56,9 +60,13 @@
     ],
     "Notification": [
       {
-        "type": "command",
-        "command": "notify-send 'Claude Code' 'En attente de ton input' 2>/dev/null || true",
-        "timeout": 3000
+        "hooks": [
+          {
+            "type": "command",
+            "command": "notify-send 'Claude Code' 'En attente de ton input' 2>/dev/null || true",
+            "timeout": 3000
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
`claude doctor` reported **Invalid settings → hooks: Expected array, but received undefined**. The `PreCompact` / `Notification` hook events stored a bare command object instead of the required `{ "hooks": [ ... ] }` wrapper. This wraps them correctly. Config-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)