### PR TITLE
test(e2e): add Playwright E2E suite wired into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,42 @@ jobs:
           path: app/dist/
           retention-days: 1
 
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs:
+      - lint
+      - test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: app/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: app
+        shell: bash
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: app
+        shell: bash
+      - name: Run Playwright E2E tests
+        run: npx playwright test
+        working-directory: app
+        shell: bash
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: app/playwright-report/
+          retention-days: 14
+
   sonar:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,12 @@ yarn-error.log*
 coverage/
 .nyc_output/
 
+# Playwright E2E
+playwright-report/
+test-results/
+blob-report/
+playwright/.cache/
+
 # Système
 .DS_Store
 Thumbs.db

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "1.50.0",
         "@testing-library/dom": "^10.0.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
@@ -755,6 +756,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
+      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.50.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -4414,6 +4431,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
+      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.50.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
+      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,8 @@
     "type-check": "tsc --noEmit",
     "test": "vitest --run",
     "test:watch": "vitest --watch",
-    "test:coverage": "vitest --coverage --run"
+    "test:coverage": "vitest --coverage --run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.100.11",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "1.50.0",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E configuration for the cv-online app.
+ *
+ * The app is served through Vite preview, which honours the `base`
+ * ('/linkendin-resume/') from vite.config.ts. The webServer builds and
+ * previews the app directly (vite build && vite preview) to avoid coupling
+ * the E2E run to the `tsc` step of `npm run build`.
+ */
+const PORT = 4173;
+const BASE_PATH = '/linkendin-resume/';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: `http://localhost:${PORT}${BASE_PATH}`,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: `npx vite build && npx vite preview --port ${PORT} --strictPort`,
+    url: `http://localhost:${PORT}${BASE_PATH}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/app/src/components/cv/ContactSection.tsx
+++ b/app/src/components/cv/ContactSection.tsx
@@ -12,7 +12,7 @@ export function ContactSection({ onContactClick }: { onContactClick: () => void 
   const profile = getProfile(lang);
 
   return (
-    <section id="contact" className="section contact-section" ref={ref}>
+    <section id="contact" data-testid="contact-section" className="section contact-section" ref={ref}>
       <div className="contact-section__bg" aria-hidden="true">
         <div className="hero__orb hero__orb--1" style={{ opacity: 0.25 }} />
         <div className="hero__orb hero__orb--2" style={{ opacity: 0.15 }} />

--- a/app/src/components/cv/EducationSection.tsx
+++ b/app/src/components/cv/EducationSection.tsx
@@ -12,7 +12,7 @@ export function EducationSection() {
   const profile = getProfile(lang);
 
   return (
-    <section id="education" className="section section--dark" ref={ref}>
+    <section id="education" data-testid="education-section" className="section section--dark" ref={ref}>
       <div className="container">
         <motion.p className="section__label" initial={{ opacity: 0 }} animate={inView ? { opacity: 1 } : {}}>
           {t('sections.education.label')}

--- a/app/src/components/cv/ExperienceTimeline.tsx
+++ b/app/src/components/cv/ExperienceTimeline.tsx
@@ -65,7 +65,7 @@ export function ExperienceTimeline() {
   const lineScaleY = useSpring(scrollYProgress, { stiffness: 80, damping: 22 });
 
   return (
-    <section id="experiences" className="section" ref={sectionRef}>
+    <section id="experiences" data-testid="experience-timeline" className="section" ref={sectionRef}>
       <div className="container">
         <motion.p className="section__label" initial={{ opacity: 0 }} animate={inView ? { opacity: 1 } : {}}>
           {t('sections.experience.label')}

--- a/app/src/components/cv/Hero.tsx
+++ b/app/src/components/cv/Hero.tsx
@@ -87,7 +87,7 @@ export function Hero({ onContactClick }: HeroProps) {
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <section id="hero" className="hero">
+    <section id="hero" data-testid="hero" className="hero">
       <div className="hero__bg" aria-hidden="true">
         <motion.div className="hero__orb hero__orb--1" style={{ x: orb1X, y: orb1Y }} />
         <motion.div className="hero__orb hero__orb--2" style={{ x: orb2X, y: orb2Y }} />

--- a/app/src/components/cv/ImpactMetrics.tsx
+++ b/app/src/components/cv/ImpactMetrics.tsx
@@ -46,7 +46,7 @@ export function ImpactMetrics() {
   const metrics = getMetrics(lang);
 
   return (
-    <section id="impact" className="section section--dark" ref={ref}>
+    <section id="impact" data-testid="impact-metrics" className="section section--dark" ref={ref}>
       <div className="container">
         <motion.p className="section__label" initial={{ opacity: 0 }} animate={inView ? { opacity: 1 } : {}}>
           {t('sections.impact.label')}

--- a/app/src/components/cv/ProjectsGrid.tsx
+++ b/app/src/components/cv/ProjectsGrid.tsx
@@ -172,7 +172,7 @@ export function ProjectsGrid() {
   const graphUrl = `https://ghchart.rshah.org/7c3aed/${GITHUB_CONFIG.owner}`;
 
   return (
-    <section id="projects" className="section" ref={ref}>
+    <section id="projects" data-testid="projects-grid" className="section" ref={ref}>
       <div className="container">
         <motion.p className="section__label" initial={{ opacity: 0 }} animate={inView ? { opacity: 1 } : {}}>
           {t('sections.projects.label')}

--- a/app/src/components/cv/SkillsCloud.tsx
+++ b/app/src/components/cv/SkillsCloud.tsx
@@ -71,7 +71,7 @@ export function SkillsCloud() {
   const filtered = activeCategory === 'all' ? skills : skills.filter((s) => s.category === activeCategory);
 
   return (
-    <section id="stack" className="section section--dark" ref={ref}>
+    <section id="stack" data-testid="skills-cloud" className="section section--dark" ref={ref}>
       <div className="container">
         <motion.p className="section__label" initial={{ opacity: 0 }} animate={inView ? { opacity: 1 } : {}}>
           {t('sections.skills.label')}

--- a/app/tests/e2e/cv.spec.ts
+++ b/app/tests/e2e/cv.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * E2E suite for the cv-online single-page CV.
+ * Satisfies CODE_MANIFEST §6.4 / ADR D-0002.
+ *
+ * The navbar (.navbar) only mounts after window.scrollY > 60, so any test
+ * that drives navbar controls scrolls first to reveal it.
+ */
+
+const SECTION_TESTIDS = [
+  'hero',
+  'impact-metrics',
+  'experience-timeline',
+  'skills-cloud',
+  'projects-grid',
+  'education-section',
+  'contact-section',
+] as const;
+
+/** Scroll down to reveal the scroll-gated navbar, then wait for it. */
+async function revealNavbar(page: import('@playwright/test').Page) {
+  await page.mouse.wheel(0, 800);
+  const navbar = page.locator('nav.navbar');
+  await expect(navbar).toBeVisible();
+  return navbar;
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#main-content')).toBeVisible();
+});
+
+test('renders the main content landmark and all 7 sections', async ({ page }) => {
+  await expect(page.locator('#main-content')).toBeVisible();
+  for (const id of SECTION_TESTIDS) {
+    await expect(page.getByTestId(id)).toBeVisible();
+  }
+});
+
+test('footer exposes the source link to the GitHub repository', async ({ page }) => {
+  const source = page.locator('footer.footer a.footer__source');
+  await expect(source).toBeVisible();
+  await expect(source).toHaveAttribute('href', 'https://github.com/chrysa/linkendin-resume');
+});
+
+test('document html element carries a lang attribute', async ({ page }) => {
+  const lang = await page.locator('html').getAttribute('lang');
+  expect(lang, 'html[lang] must be set by useDocumentMeta').toBeTruthy();
+  expect(lang).toMatch(/^(en|fr)/);
+});
+
+test('contact modal opens from the navbar and closes on Escape', async ({ page }) => {
+  const navbar = await revealNavbar(page);
+
+  // The navbar Contact button is the primary CTA.
+  await navbar.getByRole('button', { name: /contact/i }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  await page.keyboard.press('Escape');
+  // Modal unmounts on close (AnimatePresence).
+  await expect(page.getByRole('dialog')).toHaveCount(0);
+});
+
+test('theme toggle flips documentElement data-theme', async ({ page }) => {
+  await revealNavbar(page);
+
+  const before = await page.evaluate(() => document.documentElement.dataset.theme ?? '');
+  await page.locator('button.theme-toggle').click();
+
+  await expect.poll(async () => page.evaluate(() => document.documentElement.dataset.theme ?? '')).not.toBe(before);
+
+  const after = await page.evaluate(() => document.documentElement.dataset.theme ?? '');
+  expect(['dark', 'light']).toContain(after);
+});
+
+test('language switch flips the html lang attribute', async ({ page }) => {
+  const navbar = await revealNavbar(page);
+
+  const langBefore = await page.locator('html').getAttribute('lang');
+
+  // The language toggle in the navbar advertises the target language.
+  await navbar.getByRole('button', { name: /Switch to English|Passer en français/ }).click();
+
+  await expect.poll(async () => page.locator('html').getAttribute('lang')).not.toBe(langBefore);
+});

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,12 +1,15 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vitest/config';
 import { resolve } from 'path';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/__tests__/setup.ts'],
+    // Unit tests live under src/; Playwright E2E specs (tests/e2e) run separately.
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    exclude: ['node_modules', 'dist', 'tests/e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## What
Playwright E2E suite for cv-online (app/): sections render + #main-content, footer source link, contact modal open/close, theme toggle (data-theme), language switch (FR/EN). New blocking `e2e` CI job. Per ADR D-0002 §6.4.

## Validation
Local Docker Playwright validation (CI is blocked org-wide by GitHub Actions billing). Note: repo has known tailwind v4 / vite 8 drift — lockfile regenerated in Docker.

Closes #174