### PR TITLE
ci(quality-gate): fix startup_failure (grant write scopes to reusable caller)

### DIFF
--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -8,6 +8,15 @@ on:
     push:
         branches: [main, master]
 
+# The reusable quality-gate-check workflow requests checks:write and
+# statuses:write. The repo default GITHUB_TOKEN is read-only, so the caller
+# must grant these scopes explicitly, otherwise the called workflow cannot
+# start (startup_failure).
+permissions:
+    checks: write
+    contents: read
+    statuses: write
+
 jobs:
     call:
         uses: chrysa/github-actions/.github/workflows/quality-gate-check.yml@main


### PR DESCRIPTION
## Problem
`Quality Gate Check` is `startup_failure` on every run (repo default token is `read`).

## Root cause
The reusable `chrysa/github-actions/.github/workflows/quality-gate-check.yml@main` requests `checks: write` + `statuses: write`. The caller declared no `permissions:` block, so the called workflow's token can't be granted those scopes → GitHub refuses to start it.

## Fix
Declare the required scopes on the caller (same fix as discordium #117 / django-app-forge #13).

## Scope
Systemic stale-template bug across ~39 chrysa repos; this is part of the org-wide backfill. Current `shared-standards/.github` source is already correct, so new `/chrysa-init` repos are unaffected.