### PR TITLE
chore(config): normalize repo to chrysa standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.py]
+indent_size = 4
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,47 @@
+# Normalize line endings: treat all text as text, check out/in with LF.
+* text=auto eol=lf
+
+# Explicit text types
+*.py      text
+*.pyi     text
+*.md      text
+*.txt     text
+*.cfg     text
+*.ini     text
+*.toml    text
+*.yaml    text
+*.yml     text
+*.json    text
+*.js      text
+*.jsx     text
+*.ts      text
+*.tsx     text
+*.css     text
+*.html    text
+*.sh      text eol=lf
+Makefile  text
+Dockerfile text
+
+# Lockfiles & generated artefacts: keep diffs collapsed, exclude from language stats
+uv.lock           linguist-generated=true -diff
+poetry.lock       linguist-generated=true -diff
+package-lock.json linguist-generated=true -diff
+pnpm-lock.yaml    linguist-generated=true -diff
+yarn.lock         linguist-generated=true -diff
+
+# Binary assets — never normalize
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.webp  binary
+*.ico   binary
+*.pdf   binary
+*.svg   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary
+*.zip   binary
+*.gz    binary
+*.db    binary

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,13 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  call:
+    uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,11 @@ repos:
           - --allow-multiple-documents
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: detect-private-key
+      - args:
+          - --branch
+          - main
+        id: no-commit-to-branch
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:
@@ -40,7 +45,7 @@ repos:
     hooks:
       - id: gitleaks
   - repo: https://github.com/chrysa/pre-commit-tools
-    rev: v0.1.1-92
+    rev: v0.1.1-93
     hooks:
       - id: console-debug-detection
         files: '\.(js|gs|ts|tsx|jsx)$'
@@ -63,6 +68,20 @@ repos:
         exclude: ^(\.github/(workflows|ISSUE_TEMPLATE)/|GitVersion\.yml)
       - id: regression-gate
         stages: [pre-push]
+      - id: json-sorter
+      - id: env-example-sync
+      - id: adr-gate
+  # TODO: add detect-duplicated-copilot-instructions after chrysa/pre-commit-tools#163 is merged and released
+  # --- python (all Python repos) ---
+      - id: debugger-detection
+      - id: python-print-detection
+      - id: python-pprint-detection
+        exclude: 'tests?/'
+      - id: no-bare-except
+      - id: python-logger-detection
+      - id: python-unreachable-code
+      - id: no-hardcoded-localhost
+        exclude: 'tests?/|\.test\.|\.spec\.'
 
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0
@@ -70,3 +89,11 @@ repos:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.48.0
+    hooks:
+      - args:
+          - --fix
+        id: markdownlint
+        stages:
+          - manual

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to linkendin-resume
+
+Thanks for contributing. This repo follows the chrysa
+[Execution Standard](https://github.com/chrysa/shared-standards/blob/main/EXECUTION_STANDARD.md).
+
+## Prerequisites
+
+Install dev dependencies and pre-commit hooks:
+
+```bash
+make install
+```
+
+## Workflow
+
+1. **Branch** from `main` using a typed prefix: `feat/`, `fix/`, `chore/`,
+   `docs/`, `ci/`, `refactor/`, `test/`, `perf/`. Direct commits to `main` are
+   blocked (`no-commit-to-branch`).
+2. **Develop** using the `make` targets only — never call `pytest` / `ruff` /
+   `mypy` directly on the host: `make test`, `make test-cov`, `make lint`,
+   `make format`, `make typecheck`.
+3. **Commit** using [Conventional Commits](https://www.conventionalcommits.org/):
+   `type(scope): subject` (allowed types: feat, fix, docs, style, refactor, test,
+   chore, perf, revert, ci). Commit messages are linted via `conventional-pre-commit`.
+4. **Verify** before pushing, then open a PR against `main`.
+
+Verification commands:
+
+```bash
+pre-commit run --all-files
+make test
+```
+
+CI (pre-commit, lint, test, sonar) must pass and one approval is required before merge.
+
+## Code standards
+
+- All committed files (code, comments, docs, config) are in **English**.
+- No hardcoded secrets — use env vars and keep `.env.example` in sync.
+- New behaviour ships with tests; keep coverage at or above the project threshold.
+
+## Reporting issues
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/`. Include reproduction
+steps, expected vs actual behaviour, and environment details.

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -15,3 +15,14 @@ This project follows all conventions defined in `CODE_MANIFEST.md` (chrysa portf
 No active deviation is in effect. Any future deviation must be added as a new ADR entry below.
 
 ---
+
+## Adopt chrysa canonical CI/process workflows and pre-commit baseline
+
+- **Date:** 2026-06-07
+- **Status:** Accepted
+- **Context:** Repo configuration drifted from the chrysa standard (OPS-190).
+- **Decision:** Adopt the canonical hygiene files, GitHub process workflows,
+  and the Full pre-commit baseline defined in `chrysa/shared-standards`
+  (EXECUTION_STANDARD section 8/14, ADR 0001).
+- **Consequences:** CI job contract (pre-commit/lint/test/sonar) and branch
+  protection align across the ecosystem; per-repo tuning stays in this file.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Anthony Gréau
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Normalization wave (OPS-190, driven by shared-standards#84).

- **NEW** .editorconfig, .gitattributes, CONTRIBUTING.md
- **Pre-commit §8 upgrade** (gitleaks, conventional-pre-commit, no-commit-to-branch, chrysa/pre-commit-tools; non-applicable stack hooks excluded)
- dependabot + process-workflow refresh
- CI template not applied in this wave (--no-ci)

🤖 Generated with [Claude Code](https://claude.com/claude-code)