### PR TITLE
fix(makefile): declare tier (infra), rename type-check target to typecheck

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 #!make
+# makefile-tier: infra
 ifneq (,)
 	$(error This Makefile requires GNU Make)
 endif
@@ -70,6 +71,3 @@ help-%: ## Show detailed help for a specific command
 
 test-cov: ## Run tests with coverage (alias → test-coverage)
 	$(MAKE) test-coverage
-
-typecheck: ## Run type checking (alias → type-check)
-	$(MAKE) type-check

--- a/makefiles/quality.Makefile
+++ b/makefiles/quality.Makefile
@@ -12,7 +12,7 @@ lint: ensure-container ## Run ESLint
 	@echo "$(COLOR_BLUE)🔍 Linting...$(COLOR_RESET)"
 	$(call npm_simple,lint)
 
-type-check: ensure-container ## Run TypeScript type check
+typecheck: ensure-container ## Run TypeScript type check
 	@echo "$(COLOR_BLUE)📝 Type checking...$(COLOR_RESET)"
 	$(call npm_simple,type-check)
 	@echo "$(COLOR_GREEN)✓ Passed$(COLOR_RESET)"
@@ -24,7 +24,7 @@ pre-commit: ## Run pre-commit on all files
 
 ci: ensure-container ## Run all CI checks (type-check + lint + test + build)
 	@echo "$(COLOR_BLUE)🔄 Running CI checks...$(COLOR_RESET)"
-	@$(MAKE) --no-print-directory type-check
+	@$(MAKE) --no-print-directory typecheck
 	@$(MAKE) --no-print-directory lint
 	@$(MAKE) --no-print-directory test
 	@$(MAKE) --no-print-directory build-prod


### PR DESCRIPTION
Declare `# makefile-tier: infra`. Rename the forbidden `type-check` make target to the canonical `typecheck` in `makefiles/quality.Makefile` (and the `$(MAKE)` reference in `ci`), and drop the now-redundant root alias wrapper. The npm script name `npm_simple,type-check` is left untouched (that is the package.json script, not a make target).

Part of the Makefile uniformization campaign (Phase C). Enforced by the makefile-check hook (pre-commit-tools #200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)