### PR TITLE
feat(demo): add demo mode with fixture data and DEMO banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,5 +15,11 @@ IMAGE_TAG=latest
 VITE_GITHUB_OWNER=chrysa
 VITE_GITHUB_REPO=contact
 
+# ─── Demo mode ────────────────────────────────────────────────────────────────
+# When true, the app serves inline fixture data (e.g. live GitHub repos) and
+# shows a persistent amber "DEMO" banner, so it is fully explorable without any
+# real credentials or network access. Off by default.
+VITE_DEMO_MODE=false
+
 # ─── Optional ─────────────────────────────────────────────────────────────────
 # VITE_RATE_LIMIT_MAX=3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
   - repo: https://github.com/chrysa/pre-commit-tools
     rev: v0.1.1-94
     hooks:
-    - id: makefile-check
+      - id: makefile-check
       - id: console-debug-detection
         files: '\.(js|gs|ts|tsx|jsx)$'
       - id: console-log-detection

--- a/app/src/__tests__/demo-mode.test.tsx
+++ b/app/src/__tests__/demo-mode.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, renderHook, waitFor } from '@testing-library/react';
+
+// The demo flag is read through a single helper so tests can toggle it
+// deterministically without touching import.meta.env.
+const isDemoMode = vi.fn<() => boolean>();
+vi.mock('@/utils/demoMode', () => ({ isDemoMode: () => isDemoMode() }));
+
+import { DemoBanner } from '@/components/ui/DemoBanner';
+import { useGitHubRepos } from '@/hooks/useGitHubRepos';
+import { DEMO_REPOS } from '@/data/demoRepos';
+
+describe('demo mode', () => {
+  beforeEach(() => {
+    isDemoMode.mockReset();
+  });
+
+  describe('DemoBanner', () => {
+    it('renders an amber status banner when demo mode is on', () => {
+      isDemoMode.mockReturnValue(true);
+      render(<DemoBanner />);
+
+      const banner = screen.getByTestId('demo-banner');
+      expect(banner).toBeInTheDocument();
+      expect(banner).toHaveAttribute('role', 'status');
+      expect(banner).toHaveTextContent(/no real credentials/i);
+    });
+
+    it('renders nothing when demo mode is off', () => {
+      isDemoMode.mockReturnValue(false);
+      const { container } = render(<DemoBanner />);
+
+      expect(screen.queryByTestId('demo-banner')).not.toBeInTheDocument();
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  describe('useGitHubRepos', () => {
+    it('serves inline fixtures and never fetches when demo mode is on', async () => {
+      isDemoMode.mockReturnValue(true);
+      const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      const { result } = renderHook(() => useGitHubRepos({ owner: 'chrysa' }));
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.current.error).toBeNull();
+      expect(result.current.repos.length).toBeGreaterThan(0);
+      expect(result.current.repos.map((r) => r.id)).toEqual(DEMO_REPOS.map((r) => r.id));
+
+      fetchSpy.mockRestore();
+    });
+
+    it('respects perPage when slicing fixtures', async () => {
+      isDemoMode.mockReturnValue(true);
+      const { result } = renderHook(() => useGitHubRepos({ owner: 'chrysa', perPage: 2 }));
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.repos).toHaveLength(2);
+    });
+  });
+});

--- a/app/src/components/ui/DemoBanner.tsx
+++ b/app/src/components/ui/DemoBanner.tsx
@@ -1,0 +1,41 @@
+import type { CSSProperties } from 'react';
+import { isDemoMode } from '@/utils/demoMode';
+
+const bannerStyle: CSSProperties = {
+  display: 'flex',
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  justifyContent: 'center',
+  gap: '0.5rem',
+  padding: '0.4rem 1.25rem',
+  fontSize: '0.85rem',
+  fontWeight: 500,
+  // Amber on near-black — contrast ratio > 7:1 (WCAG 2.1 AA, even AAA).
+  color: '#451a03',
+  background: '#fbbf24',
+  borderBottom: '1px solid #b45309',
+  textAlign: 'center',
+};
+
+const labelStyle: CSSProperties = {
+  fontWeight: 700,
+  letterSpacing: '0.05em',
+  textTransform: 'uppercase',
+};
+
+/**
+ * Persistent amber strip shown at the very top of the page while demo mode is
+ * active (VITE_DEMO_MODE=true). It signals that every data source is serving
+ * fixture data and no real credentials are in use. Hidden entirely otherwise.
+ */
+export function DemoBanner() {
+  if (!isDemoMode()) return null;
+
+  return (
+    <div role="status" aria-live="polite" data-testid="demo-banner" style={bannerStyle}>
+      <span style={labelStyle}>Demo</span>
+      <span aria-hidden="true">—</span>
+      <span>You are exploring sample data. No real credentials are used.</span>
+    </div>
+  );
+}

--- a/app/src/data/demoRepos.ts
+++ b/app/src/data/demoRepos.ts
@@ -1,0 +1,83 @@
+import type { GitHubRepo } from '@/hooks/useGitHubRepos';
+
+/**
+ * Realistic inline fixtures served by `useGitHubRepos` while demo mode is on.
+ *
+ * The shape matches exactly what the public GitHub REST API returns for
+ * `GET /users/{owner}/repos`, so the live-repos grid renders identically to
+ * production without any network call or credential.
+ */
+export const DEMO_REPOS: GitHubRepo[] = [
+  {
+    id: 901_001,
+    name: 'portfolio-engine',
+    full_name: 'demo-user/portfolio-engine',
+    description: 'Headless content engine powering personal portfolios and CV sites.',
+    html_url: 'https://github.com/demo-user/portfolio-engine',
+    stargazers_count: 248,
+    language: 'TypeScript',
+    pushed_at: new Date(Date.now() - 2 * 86_400_000).toISOString(),
+    topics: ['react', 'vite', 'portfolio'],
+    archived: false,
+  },
+  {
+    id: 901_002,
+    name: 'flux-api',
+    full_name: 'demo-user/flux-api',
+    description: 'Async FastAPI service with SQLAlchemy 2.0 and end-to-end typing.',
+    html_url: 'https://github.com/demo-user/flux-api',
+    stargazers_count: 132,
+    language: 'Python',
+    pushed_at: new Date(Date.now() - 9 * 86_400_000).toISOString(),
+    topics: ['fastapi', 'async', 'postgres'],
+    archived: false,
+  },
+  {
+    id: 901_003,
+    name: 'design-tokens',
+    full_name: 'demo-user/design-tokens',
+    description: 'Accessible design-token system with dark mode and WCAG AA contrast.',
+    html_url: 'https://github.com/demo-user/design-tokens',
+    stargazers_count: 87,
+    language: 'CSS',
+    pushed_at: new Date(Date.now() - 21 * 86_400_000).toISOString(),
+    topics: ['design-system', 'accessibility', 'tailwind'],
+    archived: false,
+  },
+  {
+    id: 901_004,
+    name: 'agent-ops',
+    full_name: 'demo-user/agent-ops',
+    description: 'Observability and guardrails toolkit for long-lived LLM agents.',
+    html_url: 'https://github.com/demo-user/agent-ops',
+    stargazers_count: 56,
+    language: 'Python',
+    pushed_at: new Date(Date.now() - 45 * 86_400_000).toISOString(),
+    topics: ['llm', 'observability', 'agents'],
+    archived: false,
+  },
+  {
+    id: 901_005,
+    name: 'ci-templates',
+    full_name: 'demo-user/ci-templates',
+    description: 'Reusable GitHub Actions workflows for Python and TypeScript projects.',
+    html_url: 'https://github.com/demo-user/ci-templates',
+    stargazers_count: 41,
+    language: 'YAML',
+    pushed_at: new Date(Date.now() - 70 * 86_400_000).toISOString(),
+    topics: ['github-actions', 'ci', 'devops'],
+    archived: false,
+  },
+  {
+    id: 901_006,
+    name: 'edge-cache',
+    full_name: 'demo-user/edge-cache',
+    description: 'Tiny Redis-backed read-through cache with stale-while-revalidate.',
+    html_url: 'https://github.com/demo-user/edge-cache',
+    stargazers_count: 23,
+    language: 'Go',
+    pushed_at: new Date(Date.now() - 120 * 86_400_000).toISOString(),
+    topics: ['redis', 'cache', 'performance'],
+    archived: false,
+  },
+];

--- a/app/src/hooks/useGitHubRepos.ts
+++ b/app/src/hooks/useGitHubRepos.ts
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react';
+import { isDemoMode } from '@/utils/demoMode';
+import { DEMO_REPOS } from '@/data/demoRepos';
 
 export interface GitHubRepo {
   id: number;
@@ -30,6 +32,14 @@ export function useGitHubRepos({ owner, perPage = 12 }: UseGitHubReposOptions): 
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    // Demo mode: serve inline fixtures, never touch the real GitHub API.
+    if (isDemoMode()) {
+      setRepos(DEMO_REPOS.filter((r) => !r.archived).slice(0, perPage));
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
     if (!owner || owner === 'votre-username') {
       setLoading(false);
       return;

--- a/app/src/pages/CVPage.tsx
+++ b/app/src/pages/CVPage.tsx
@@ -16,6 +16,7 @@ import { AccessibilityPanel } from '@/components/ui/AccessibilityPanel';
 import { TerminalEasterEgg } from '@/components/ui/TerminalEasterEgg';
 import { CommandPalette } from '@/components/ui/CommandPalette';
 import { AskMeWidget } from '@/components/ui/AskMeWidget';
+import { DemoBanner } from '@/components/ui/DemoBanner';
 import { useDocumentMeta } from '@/hooks/useDocumentMeta';
 
 export function CVPage() {
@@ -26,6 +27,7 @@ export function CVPage() {
 
   return (
     <>
+      <DemoBanner />
       <ScrollProgress />
       <CustomCursor />
       <Navbar onContactClick={openModal} />

--- a/app/src/utils/demoMode.ts
+++ b/app/src/utils/demoMode.ts
@@ -1,0 +1,11 @@
+/**
+ * Demo mode flag.
+ *
+ * Driven by the `VITE_DEMO_MODE` build-time env var (off by default). When on,
+ * every external-API read path serves realistic inline fixtures instead of
+ * hitting real services (e.g. the public GitHub API), so the whole app is
+ * explorable without any real credentials or network access.
+ */
+export function isDemoMode(): boolean {
+  return import.meta.env.VITE_DEMO_MODE === 'true';
+}

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_GITHUB_OWNER: string;
   readonly VITE_GITHUB_REPO: string;
   readonly VITE_RATE_LIMIT_MAX: string;
+  readonly VITE_DEMO_MODE: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Adds a portfolio-wide **demo mode** so the CV web app is fully explorable on fixture data, with no real credentials or network access. Gated by a `VITE_DEMO_MODE` flag that is **off by default**.

## What changed

- **`VITE_DEMO_MODE` flag** — read via `isDemoMode()` (`app/src/utils/demoMode.ts`), off by default.
- **Fixtures on the external read path** — `useGitHubRepos` returns inline `DEMO_REPOS` (matching the GitHub REST `GET /users/{owner}/repos` schema) instead of calling `api.github.com` when demo mode is on. This is the only real external-API read in the SPA.
- **`DemoBanner`** — persistent amber strip (`role="status"`, `aria-live="polite"`, `data-testid="demo-banner"`, WCAG 2.1 AA contrast) mounted at the top of the layout (`CVPage`), shown on every page while demo mode is active, hidden otherwise.
- **`.env.example`** — documents `VITE_DEMO_MODE=false`.
- **Tests** — `app/src/__tests__/demo-mode.test.tsx`: banner visibility on/off, and the hook serving fixtures without ever fetching.

## Test / build status

`make docker-test` → 120/120 tests pass (4 new). Type-check, ESLint, and production build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)