### PR TITLE
design(frontend): Neon Brutalist re-skin (yellow accent)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -26,3 +26,24 @@ No active deviation is in effect. Any future deviation must be added as a new AD
   (EXECUTION_STANDARD section 8/14, ADR 0001).
 - **Consequences:** CI job contract (pre-commit/lint/test/sonar) and branch
   protection align across the ecosystem; per-repo tuning stays in this file.
+
+---
+
+## D-0002 — Adopt Neon Brutalist design system (yellow accent)
+
+- **Date:** 2026-06-12
+- **Status:** Accepted
+- **Context:** linkendin-resume's turn in the 17-repo design campaign rolling out
+  the shared-standards Neon Brutalist system. The prior look was soft (violet→cyan
+  gradient accent, glow shadows, rounded) — the opposite of the chosen DNA.
+- **Decision:** Rewrote the token layer in `app/src/styles/tokens.css` and swept
+  the consuming stylesheets to the brutalist contract — flat single acid accent
+  (no gradient), `--radius 0`, 2px FG-colored borders, hard `4px 4px 0` shadows
+  (no blur/glow), Space Grotesk + JetBrains Mono. Per-app accent assigned as
+  **acid yellow** `#ffe600` (dark) / `#e0c400` (light), distinct from all other
+  campaign hues; used as fill blocks with `#0e0e10` ink.
+- **Consequences:** The `html[data-theme]` mechanism, the FOUC guard
+  (`localStorage['theme']`), and the `data-high-contrast` / `data-dyslexia` /
+  `data-reduced-motion` accessibility datasets are all preserved. All Vitest +
+  Playwright test selectors are unchanged; `cv.json` and component logic untouched.
+  See `app/DESIGN.md`.

--- a/app/DESIGN.md
+++ b/app/DESIGN.md
@@ -1,0 +1,46 @@
+# Design — linkendin-resume (cv-online)
+
+This frontend follows the chrysa **Neon Brutalist** design system:
+[`shared-standards/docs/DESIGN-SYSTEM.md`](https://github.com/chrysa/shared-standards/blob/main/docs/DESIGN-SYSTEM.md).
+
+## Aesthetic
+
+Loud structure, flat fills, one acid accent. Radius `0`, 2px FG-colored borders
+(white on dark / black on light), hard offset shadows (`4px 4px 0`), **no
+gradients, no glow**, mono-forward type.
+
+## Per-app accent
+
+**Acid yellow** — `#ffe600` (dark) · `#e0c400` (light, darker variant for fill
+contrast). Used only as **fill blocks** with `--accent-ink` (`#0e0e10`) text,
+never as acid text on the background. Distinct from every other campaign hue
+(lime/cyan/violet/orange/magenta/azure).
+
+## Type
+
+- Display / body: **Space Grotesk** (`--font-sans`)
+- Mono (labels, dates, tech tags, metrics): **JetBrains Mono** (`--font-mono`)
+
+Loaded via Google Fonts in `app/index.html`.
+
+## Tokens
+
+The single source of truth is `app/src/styles/tokens.css`. Every other
+stylesheet (`globals`, `components`, `sections`, `modal`, `animations`,
+`responsive`) reads its CSS custom properties, so re-theming happens in one
+place.
+
+## Theme mechanism (preserved)
+
+- `data-theme="dark" | "light"` on `<html>`, set by the FOUC guard in
+  `index.html` from `localStorage['theme']` and `prefers-color-scheme`, managed
+  at runtime by `useTheme` / `ThemeProvider`.
+- **Accessibility datasets** are preserved and still drive token overrides:
+  `data-high-contrast`, `data-dyslexia`, `data-reduced-motion`.
+
+## Constraints honoured
+
+- WCAG 2.1 AA in both themes; yellow accent fills carry `#0e0e10` ink.
+- All test selectors (`data-testid`, roles, aria-labels, ids/classes queried by
+  Vitest + Playwright) are unchanged — this was a restyle only.
+- Content remains data-driven from `app/cv.json`; no component logic changed.

--- a/app/index.html
+++ b/app/index.html
@@ -28,7 +28,8 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet" />
+    <!-- Neon Brutalist type — Space Grotesk (display) + JetBrains Mono -->
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet" />
     <script>
       (function () {
         var t = localStorage.getItem('theme');

--- a/app/src/styles/animations.css
+++ b/app/src/styles/animations.css
@@ -5,7 +5,7 @@
   left: 0;
   right: 0;
   height: 3px;
-  background: linear-gradient(90deg, var(--clr-accent-1), var(--clr-accent-2));
+  background: var(--clr-accent-1);
   transform-origin: left;
   z-index: 9999;
   pointer-events: none;
@@ -34,13 +34,14 @@
   align-items: center;
   gap: 0.55rem;
   padding: 0.75rem 1.35rem;
-  background: linear-gradient(135deg, var(--clr-accent-1), var(--clr-accent-2));
-  color: #fff;
+  background: var(--clr-accent-1);
+  color: var(--accent-ink);
   font-family: var(--font-sans);
   font-weight: 700;
   font-size: 0.9rem;
-  border-radius: var(--radius-full);
-  box-shadow: 0 8px 32px rgba(124, 58, 237, 0.45);
+  border: 2px solid var(--clr-border);
+  border-radius: 0;
+  box-shadow: var(--shadow-card);
   cursor: pointer;
   transition: var(--transition);
 }
@@ -55,7 +56,7 @@
   }
   .floating-cta {
     padding: 0.85rem;
-    border-radius: 50%;
+    border-radius: 0;
   }
 }
 
@@ -66,13 +67,11 @@
   left: 50%;
   transform: translateX(-50%);
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
   border-radius: var(--radius-md);
   padding: 0.7rem 0.9rem;
   min-width: 160px;
-  box-shadow:
-    0 12px 40px rgba(0, 0, 0, 0.5),
-    var(--shadow-glow);
+  box-shadow: var(--shadow-card);
   z-index: 100;
   pointer-events: none;
   white-space: nowrap;

--- a/app/src/styles/components.css
+++ b/app/src/styles/components.css
@@ -21,9 +21,9 @@
   z-index: 200;
   width: 2.8rem;
   height: 2.8rem;
-  border-radius: var(--radius-full);
+  /* Brutalist: square, 2px border, hard shadow */
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
   color: var(--clr-text-2);
   display: flex;
   align-items: center;
@@ -39,8 +39,8 @@
 .a11y-trigger:hover,
 .a11y-trigger[aria-expanded='true'] {
   background: var(--clr-accent-1);
-  color: #fff;
-  border-color: transparent;
+  color: var(--accent-ink);
+  border-color: var(--clr-border);
 }
 .a11y-trigger:focus-visible {
   outline: 2px solid var(--clr-accent-1);
@@ -54,8 +54,7 @@
   z-index: 200;
   width: 280px;
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
-  border-radius: var(--radius-lg);
+  border: 2px solid var(--clr-border);
   box-shadow: var(--shadow-card);
   padding: 1.25rem;
   display: flex;
@@ -64,11 +63,12 @@
 }
 
 .a11y-panel__title {
-  font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--clr-text-2);
+  font-size: 0.75rem;
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--clr-accent-1);
   text-transform: uppercase;
-  letter-spacing: 0.06em;
+  letter-spacing: 0.08em;
 }
 
 .a11y-row {
@@ -95,14 +95,15 @@
   min-width: 2ch;
   text-align: center;
   color: var(--clr-text-2);
+  font-family: var(--font-mono);
 }
 
 .a11y-step-btn {
   width: 1.6rem;
   height: 1.6rem;
-  border-radius: var(--radius-sm);
+  /* Brutalist: square, 2px border */
   background: var(--clr-bg-2);
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
   color: var(--clr-text);
   cursor: pointer;
   display: flex;
@@ -112,8 +113,8 @@
 }
 .a11y-step-btn:hover {
   background: var(--clr-accent-1);
-  color: #fff;
-  border-color: transparent;
+  color: var(--accent-ink);
+  border-color: var(--clr-border);
 }
 .a11y-step-btn:disabled {
   opacity: 0.35;
@@ -135,9 +136,9 @@
 .a11y-toggle__track {
   width: 2.4rem;
   height: 1.35rem;
-  border-radius: var(--radius-full);
+  /* Brutalist: square track */
   background: var(--clr-bg-2);
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
   position: relative;
   transition: background var(--transition);
   flex-shrink: 0;
@@ -149,7 +150,7 @@
   left: 2px;
   width: 0.9rem;
   height: 0.9rem;
-  border-radius: 50%;
+  /* Square thumb */
   background: var(--clr-text-2);
   transition:
     transform var(--transition),
@@ -157,11 +158,11 @@
 }
 .a11y-toggle[aria-pressed='true'] .a11y-toggle__track {
   background: var(--clr-accent-1);
-  border-color: transparent;
+  border-color: var(--clr-border);
 }
 .a11y-toggle[aria-pressed='true'] .a11y-toggle__track::after {
   transform: translateX(1.05rem);
-  background: #fff;
+  background: var(--accent-ink);
 }
 .a11y-toggle__label {
   font-size: 0.88rem;
@@ -170,15 +171,13 @@
 .a11y-toggle:focus-visible {
   outline: 2px solid var(--clr-accent-1);
   outline-offset: 2px;
-  border-radius: 4px;
 }
 
 .a11y-reset {
   width: 100%;
   padding: 0.45rem 0.75rem;
   background: var(--clr-bg-2);
-  border: 1px solid var(--clr-border);
-  border-radius: var(--radius-sm);
+  border: 2px solid var(--clr-border);
   color: var(--clr-text-2);
   font-size: 0.82rem;
   cursor: pointer;
@@ -186,11 +185,12 @@
   transition:
     background var(--transition),
     color var(--transition);
+  font-family: var(--font-sans);
 }
 .a11y-reset:hover {
   background: var(--clr-accent-1);
-  color: #fff;
-  border-color: transparent;
+  color: var(--accent-ink);
+  border-color: var(--clr-border);
 }
 .a11y-reset:focus-visible {
   outline: 2px solid var(--clr-accent-1);
@@ -203,8 +203,7 @@
   position: fixed;
   inset: 0;
   z-index: 300;
-  background: rgba(0, 0, 0, 0.65);
-  backdrop-filter: blur(4px);
+  background: rgba(0, 0, 0, 0.8);
 }
 
 .terminal {
@@ -216,14 +215,12 @@
   width: min(640px, 96vw);
   height: min(400px, 85vh);
   background: #0d1117;
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: var(--radius-lg);
+  /* Brutalist: 2px border, hard shadow */
+  border: 2px solid var(--clr-border);
+  box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  box-shadow:
-    0 32px 80px rgba(0, 0, 0, 0.7),
-    0 0 0 1px rgba(255, 255, 255, 0.05);
   font-family: var(--font-mono);
 }
 
@@ -233,7 +230,7 @@
   gap: 0.5rem;
   padding: 0.6rem 1rem;
   background: #161b22;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+  border-bottom: 2px solid var(--clr-border);
   user-select: none;
   flex-shrink: 0;
 }
@@ -247,7 +244,7 @@
   background: #ff5f57;
 }
 .terminal__dot--yellow {
-  background: #febc2e;
+  background: var(--clr-accent-1);
 }
 .terminal__dot--green {
   background: #28c840;
@@ -258,6 +255,7 @@
   text-align: center;
   font-size: 0.75rem;
   color: rgba(255, 255, 255, 0.4);
+  font-family: var(--font-mono);
 }
 
 .terminal__output {
@@ -268,7 +266,7 @@
   flex-direction: column;
   gap: 0.2rem;
   scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.1) transparent;
+  scrollbar-color: var(--clr-border) transparent;
 }
 
 .terminal__line {
@@ -278,7 +276,7 @@
   word-break: break-word;
 }
 .terminal__line--input {
-  color: #7ee787;
+  color: var(--clr-accent-1);
 }
 .terminal__line--output {
   color: #cdd9e5;
@@ -292,13 +290,13 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.6rem 1rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.07);
+  border-top: 2px solid var(--clr-border);
   background: #0d1117;
   flex-shrink: 0;
 }
 
 .terminal__prompt {
-  color: #7ee787;
+  color: var(--clr-accent-1);
   font-size: 0.82rem;
   flex-shrink: 0;
   font-family: var(--font-mono);
@@ -312,7 +310,7 @@
   color: #cdd9e5;
   font-family: var(--font-mono);
   font-size: 0.82rem;
-  caret-color: #7ee787;
+  caret-color: var(--clr-accent-1);
 }
 
 /* ─── Command Palette ─────────────────────────────────────────────────── */
@@ -321,8 +319,7 @@
   position: fixed;
   inset: 0;
   z-index: 400;
-  background: rgba(0, 0, 0, 0.55);
-  backdrop-filter: blur(4px);
+  background: rgba(0, 0, 0, 0.7);
 }
 
 .palette {
@@ -334,9 +331,8 @@
   width: min(600px, 96vw);
   max-height: 70vh;
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
-  border-radius: var(--radius-lg);
-  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.5);
+  border: 2px solid var(--clr-border);
+  box-shadow: var(--shadow-card);
   overflow: hidden;
   display: flex;
   flex-direction: column;
@@ -347,7 +343,7 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.9rem 1rem;
-  border-bottom: 1px solid var(--clr-border);
+  border-bottom: 2px solid var(--clr-border);
   flex-shrink: 0;
 }
 
@@ -375,10 +371,9 @@
   font-size: 0.7rem;
   color: var(--clr-text-3);
   background: var(--clr-bg-2);
-  border: 1px solid var(--clr-border);
-  border-radius: var(--radius-sm);
+  border: 2px solid var(--clr-border);
   padding: 0.15rem 0.4rem;
-  font-family: var(--font-sans);
+  font-family: var(--font-mono);
   flex-shrink: 0;
 }
 
@@ -404,10 +399,11 @@
 .palette__group-label {
   padding: 0.3rem 1rem;
   font-size: 0.72rem;
-  font-weight: 600;
+  font-weight: 700;
+  font-family: var(--font-mono);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--clr-text-3);
+  color: var(--clr-accent-1);
 }
 
 .palette__item {
@@ -427,8 +423,9 @@
 }
 .palette__item:hover,
 .palette__item--selected {
-  background: rgba(124, 58, 237, 0.12);
-  color: var(--clr-accent-text);
+  background: var(--clr-bg-card-hover);
+  color: var(--clr-text);
+  border-left: 4px solid var(--clr-accent-1);
 }
 .palette__item:focus-visible {
   outline: 2px solid var(--clr-accent-1);
@@ -442,7 +439,7 @@
 }
 .palette__item--selected .palette__item-icon,
 .palette__item:hover .palette__item-icon {
-  color: var(--clr-accent-text);
+  color: var(--clr-accent-1);
 }
 
 .palette__footer {
@@ -450,7 +447,7 @@
   align-items: center;
   gap: 1.25rem;
   padding: 0.55rem 1rem;
-  border-top: 1px solid var(--clr-border);
+  border-top: 2px solid var(--clr-border);
   font-size: 0.72rem;
   color: var(--clr-text-3);
   flex-shrink: 0;
@@ -461,8 +458,7 @@ kbd {
   display: inline-block;
   padding: 0.1em 0.35em;
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
-  border-radius: 4px;
+  border: 2px solid var(--clr-border);
   font-family: var(--font-mono);
   font-size: 0.72rem;
   line-height: 1.4;
@@ -473,19 +469,18 @@ kbd {
 
 .github-graph {
   margin: 2rem 0;
-  border-radius: var(--radius-md);
   overflow: hidden;
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
   background: var(--clr-bg-card);
   padding: 1rem;
   text-align: center;
+  box-shadow: var(--shadow-card);
 }
 
 .github-graph img,
 .github-graph__img {
   width: 100%;
   height: auto;
-  border-radius: var(--radius-sm);
 }
 
 .projects__grid--spaced {
@@ -494,20 +489,20 @@ kbd {
 
 .projects__sub-title {
   font-size: clamp(1.1rem, 2vw, 1.3rem);
-  font-weight: 600;
+  font-weight: 700;
   color: var(--clr-text);
   margin: 0 0 1.25rem;
+  font-family: var(--font-mono);
 }
 
 .project-card--skeleton {
   pointer-events: none;
 }
 
+/* Skeleton: brutalist flat shimmer, no gradient */
 .skeleton {
-  border-radius: var(--radius-sm);
-  background: linear-gradient(90deg, var(--clr-bg-2) 0%, var(--clr-bg-card-hover) 50%, var(--clr-bg-2) 100%);
-  background-size: 200% 100%;
-  animation: skeleton-shimmer 1.5s infinite;
+  background: var(--clr-bg-card-hover);
+  animation: skeleton-shimmer 1.5s ease-in-out infinite;
   height: 1rem;
 }
 
@@ -527,11 +522,12 @@ kbd {
 }
 
 @keyframes skeleton-shimmer {
-  0% {
-    background-position: 200% 0;
-  }
+  0%,
   100% {
-    background-position: -200% 0;
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
   }
 }
 
@@ -544,16 +540,16 @@ kbd {
   z-index: 200;
   width: 3rem;
   height: 3rem;
-  border-radius: var(--radius-full);
-  background: var(--gradient);
-  border: none;
-  color: #fff;
+  /* Brutalist: square, accent fill, 2px border */
+  background: var(--clr-accent-1);
+  border: 2px solid var(--clr-border);
+  color: var(--accent-ink);
   font-size: 1.3rem;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  box-shadow: 0 4px 20px rgba(124, 58, 237, 0.45);
+  box-shadow: var(--shadow-glow);
 }
 .askme-trigger:focus-visible {
   outline: 2px solid var(--clr-accent-1);
@@ -567,11 +563,8 @@ kbd {
   z-index: 200;
   width: min(340px, 96vw);
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
-  border-radius: var(--radius-lg);
-  box-shadow:
-    var(--shadow-card),
-    0 0 40px rgba(124, 58, 237, 0.15);
+  border: 2px solid var(--clr-border);
+  box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -581,7 +574,7 @@ kbd {
   display: flex;
   align-items: center;
   padding: 0.75rem 1rem;
-  border-bottom: 1px solid var(--clr-border);
+  border-bottom: 2px solid var(--clr-border);
   background: var(--clr-bg-2);
   flex-shrink: 0;
 }
@@ -589,8 +582,9 @@ kbd {
 .askme-panel__title {
   flex: 1;
   font-size: 0.9rem;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--clr-text);
+  font-family: var(--font-mono);
 }
 
 .askme-panel__close {
@@ -609,7 +603,6 @@ kbd {
 }
 .askme-panel__close:focus-visible {
   outline: 2px solid var(--clr-accent-1);
-  border-radius: 4px;
 }
 
 .askme-panel__messages {
@@ -628,25 +621,25 @@ kbd {
 .askme-msg {
   max-width: 85%;
   padding: 0.55rem 0.85rem;
-  border-radius: var(--radius-md);
   font-size: 0.85rem;
   line-height: 1.5;
   word-break: break-word;
+  /* Brutalist: sharp corner */
+  border: 2px solid var(--clr-border);
 }
 
 .askme-msg--user {
   align-self: flex-end;
   background: var(--clr-accent-1);
-  color: #fff;
-  border-bottom-right-radius: 4px;
+  color: var(--accent-ink);
+  border-color: var(--clr-border);
 }
 
 .askme-msg--assistant {
   align-self: flex-start;
   background: var(--clr-bg-2);
   color: var(--clr-text);
-  border: 1px solid var(--clr-border);
-  border-bottom-left-radius: 4px;
+  border-color: var(--clr-border);
 }
 
 /* Typing indicator */
@@ -659,7 +652,7 @@ kbd {
 .askme-msg--typing span {
   width: 6px;
   height: 6px;
-  border-radius: 50%;
+  /* Square dots: brutalist */
   background: var(--clr-text-3);
   animation: typing-bounce 1.2s infinite;
 }
@@ -686,15 +679,14 @@ kbd {
   align-items: center;
   gap: 0.5rem;
   padding: 0.6rem 0.75rem;
-  border-top: 1px solid var(--clr-border);
+  border-top: 2px solid var(--clr-border);
   flex-shrink: 0;
 }
 
 .askme-panel__input {
   flex: 1;
   background: var(--clr-bg-2);
-  border: 1px solid var(--clr-border);
-  border-radius: var(--radius-sm);
+  border: 2px solid var(--clr-border);
   padding: 0.45rem 0.75rem;
   color: var(--clr-text);
   font-size: 0.85rem;
@@ -712,10 +704,9 @@ kbd {
 .askme-panel__send {
   width: 2rem;
   height: 2rem;
-  border-radius: var(--radius-sm);
   background: var(--clr-accent-1);
-  border: none;
-  color: #fff;
+  border: 2px solid var(--clr-border);
+  color: var(--accent-ink);
   font-size: 0.9rem;
   display: flex;
   align-items: center;
@@ -723,7 +714,7 @@ kbd {
   cursor: pointer;
   transition:
     opacity var(--transition),
-    background var(--transition);
+    box-shadow var(--transition);
   flex-shrink: 0;
 }
 .askme-panel__send:disabled {
@@ -731,7 +722,7 @@ kbd {
   cursor: not-allowed;
 }
 .askme-panel__send:hover:not(:disabled) {
-  background: var(--clr-accent-2);
+  box-shadow: var(--shadow-glow);
 }
 .askme-panel__send:focus-visible {
   outline: 2px solid var(--clr-accent-1);

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -57,14 +57,14 @@ button {
   font-family: inherit;
 }
 
-/* ─── Accessibilité — Focus visible ─────────────────────────────────────── */
+/* ─── Accessibilite — Focus visible ─────────────────────────────────────── */
+/* Brutalist focus: 2px offset outline in accent, no radius */
 :focus-visible {
   outline: 2px solid var(--clr-accent-1);
   outline-offset: 3px;
-  border-radius: var(--radius-sm);
 }
 
-/* ─── Accessibilité — Skip Nav ──────────────────────────────────────────── */
+/* ─── Accessibilite — Skip Nav ──────────────────────────────────────────── */
 .skip-nav {
   position: fixed;
   top: -100%;
@@ -72,16 +72,17 @@ button {
   z-index: 9999;
   padding: 0.75rem 1.25rem;
   background: var(--clr-accent-1);
-  color: #fff;
+  color: var(--accent-ink);
   font-weight: 700;
   font-size: 0.9rem;
-  border-radius: var(--radius-md);
   text-decoration: none;
   transition: top 0.2s;
+  /* Brutalist: no radius, 2px border */
+  border: 2px solid var(--clr-border);
 }
 .skip-nav:focus {
   top: var(--space-md);
-  outline: 2px solid #fff;
+  outline: 2px solid var(--accent-ink);
   outline-offset: 2px;
 }
 
@@ -93,20 +94,17 @@ button {
   padding: 0 var(--space-xl);
 }
 
+/* gradient-text: brutalist — solid accent colour, no background-clip trick */
 .gradient-text {
-  background: var(--gradient-text);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--clr-accent-1);
 }
 
 .tag {
   display: inline-block;
   padding: 2px 10px;
-  background: rgba(124, 58, 237, 0.15);
-  color: var(--clr-accent-2);
-  border: 1px solid rgba(124, 58, 237, 0.3);
-  border-radius: var(--radius-full);
+  background: var(--clr-accent-1);
+  color: var(--accent-ink);
+  border: 2px solid var(--clr-border);
   font-size: 0.75rem;
   font-family: var(--font-mono);
   white-space: nowrap;
@@ -118,33 +116,36 @@ button {
   align-items: center;
   gap: var(--space-sm);
   padding: 0.65rem 1.4rem;
-  border-radius: var(--radius-full);
   font-size: 0.9rem;
-  font-weight: 600;
+  font-weight: 700;
   transition: var(--transition);
   font-family: var(--font-sans);
+  cursor: pointer;
+  /* Brutalist: no radius, 2px border */
+  border: 2px solid var(--clr-border);
 }
 
 .btn--primary {
-  background: var(--gradient);
-  color: #fff;
+  background: var(--clr-accent-1);
+  color: var(--accent-ink);
+  border-color: var(--clr-border);
   box-shadow: var(--shadow-glow);
 }
 .btn--primary:hover {
-  filter: brightness(1.12);
-  box-shadow: 0 0 40px rgba(124, 58, 237, 0.45);
-  transform: translateY(-2px);
+  box-shadow: var(--shadow-card);
+  transform: translate(-2px, -2px);
 }
 
 .btn--ghost {
   background: transparent;
   color: var(--clr-text);
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
 }
 .btn--ghost:hover {
-  border-color: var(--clr-border-hover);
-  background: rgba(124, 58, 237, 0.08);
-  transform: translateY(-2px);
+  border-color: var(--clr-accent-1);
+  background: var(--clr-bg-card-hover);
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-card);
 }
 
 .btn--sm {
@@ -192,11 +193,16 @@ button {
 }
 
 .section__label {
-  font-size: 0.8rem;
+  display: inline-block;
+  font-size: 0.75rem;
   font-weight: 700;
+  font-family: var(--font-mono);
   letter-spacing: 0.12em;
   text-transform: uppercase;
-  color: var(--clr-accent-text);
+  /* Brutalist label: accent fill block */
+  background: var(--clr-accent-1);
+  color: var(--accent-ink);
+  padding: 2px 8px;
   margin-bottom: var(--space-sm);
 }
 
@@ -217,7 +223,6 @@ button {
   background: none;
   border: none;
   cursor: pointer;
-  /* accessible click target */
   min-width: 44px;
   min-height: 44px;
   justify-content: center;
@@ -229,23 +234,23 @@ button {
   align-items: center;
   width: 56px;
   height: 28px;
-  border-radius: var(--radius-full);
+  /* Brutalist: no radius on track */
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
   overflow: hidden;
   transition:
-    background 0.4s,
-    border-color 0.4s;
+    background var(--transition),
+    border-color var(--transition);
 }
 
 [data-theme='dark'] .theme-toggle__track {
-  background: linear-gradient(135deg, #1a1035 0%, #0f1535 100%);
-  border-color: rgba(124, 58, 237, 0.3);
+  background: var(--clr-bg-2);
+  border-color: var(--clr-border);
 }
 
 [data-theme='light'] .theme-toggle__track {
-  background: linear-gradient(135deg, #d0e8ff 0%, #fffbe6 100%);
-  border-color: rgba(250, 180, 50, 0.5);
+  background: var(--clr-bg-2);
+  border-color: var(--clr-border);
 }
 
 .theme-toggle__thumb {
@@ -254,18 +259,17 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: var(--gradient);
-  box-shadow: 0 2px 8px rgba(124, 58, 237, 0.4);
-  color: #fff;
+  width: 20px;
+  height: 20px;
+  /* Brutalist: square thumb, accent fill */
+  background: var(--clr-accent-1);
+  color: var(--accent-ink);
   z-index: 2;
 }
 
 [data-theme='light'] .theme-toggle__thumb {
-  background: linear-gradient(135deg, #f97316, #facc15);
-  box-shadow: 0 2px 8px rgba(249, 115, 22, 0.4);
+  background: var(--clr-accent-1);
+  color: var(--accent-ink);
 }
 
 .theme-toggle__icon {
@@ -273,7 +277,7 @@ button {
   height: 14px;
 }
 
-/* Stars decoration (dark mode) */
+/* Stars decoration (dark mode) — kept, animations are functional (state signal) */
 .theme-toggle__stars {
   position: absolute;
   inset: 0;
@@ -327,7 +331,7 @@ button {
 
 /* ─── Footer ────────────────────────────────────────────────────────────── */
 .footer {
-  border-top: 1px solid var(--clr-border);
+  border-top: 2px solid var(--clr-border);
   padding: var(--space-xl) 0;
 }
 .footer__inner {
@@ -348,5 +352,5 @@ button {
   transition: var(--transition);
 }
 .footer__source:hover {
-  color: var(--clr-accent-2);
+  color: var(--clr-text);
 }

--- a/app/src/styles/modal.css
+++ b/app/src/styles/modal.css
@@ -3,8 +3,7 @@
   position: fixed;
   inset: 0;
   z-index: 200;
-  background: rgba(0, 0, 0, 0.75);
-  backdrop-filter: blur(6px);
+  background: rgba(0, 0, 0, 0.85);
 }
 
 .modal {
@@ -26,12 +25,10 @@
   max-height: 90dvh;
   overflow-y: auto;
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
   border-radius: var(--radius-lg);
   padding: var(--space-2xl);
-  box-shadow:
-    0 24px 80px rgba(0, 0, 0, 0.6),
-    var(--shadow-glow);
+  box-shadow: var(--shadow-card);
   position: relative;
   pointer-events: all;
 }
@@ -88,7 +85,7 @@
 
 .form-field__input {
   background: var(--clr-bg-2);
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
   border-radius: var(--radius-md);
   padding: 0.7rem 1rem;
   color: var(--clr-text);
@@ -100,13 +97,13 @@
 }
 .form-field__input:focus {
   border-color: var(--clr-accent-1);
-  box-shadow: 0 0 0 3px rgba(124, 58, 237, 0.2);
+  box-shadow: 0 0 0 2px var(--clr-accent-1);
 }
 .form-field__input--error {
   border-color: #ef4444;
 }
 .form-field__input--error:focus {
-  box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.2);
+  box-shadow: 0 0 0 2px #ef4444;
 }
 .form-field__textarea {
   resize: vertical;
@@ -166,7 +163,7 @@
   gap: 0.5rem;
   margin: var(--space-lg) 0 var(--space-md);
   background: var(--clr-bg-2);
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
   border-radius: var(--radius-md);
   padding: 0.3rem;
 }
@@ -178,7 +175,7 @@
   justify-content: center;
   gap: 0.45rem;
   padding: 0.55rem 0.75rem;
-  border-radius: calc(var(--radius-md) - 2px);
+  border-radius: 0;
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--clr-text-2);
@@ -191,11 +188,11 @@
 }
 .modal__tab--active {
   background: var(--clr-accent-1);
-  color: #fff;
+  color: var(--accent-ink);
 }
 .modal__tab--active:hover {
   background: var(--clr-accent-2);
-  color: #fff;
+  color: var(--accent-ink);
 }
 
 /* ─── WhatsApp panel ────────────────────────────────────────────────────── */
@@ -215,6 +212,5 @@
 }
 .btn--whatsapp:hover {
   background: #1ebe5d;
-  transform: translateY(-2px);
-  box-shadow: 0 8px 32px rgba(37, 211, 102, 0.4);
+  box-shadow: var(--shadow-card);
 }

--- a/app/src/styles/sections.css
+++ b/app/src/styles/sections.css
@@ -6,9 +6,8 @@
   right: 0;
   z-index: 100;
   padding: 0.75rem var(--space-xl);
-  background: rgba(10, 10, 15, 0.85);
-  backdrop-filter: blur(16px);
-  border-bottom: 1px solid var(--clr-border);
+  background: var(--clr-bg);
+  border-bottom: 2px solid var(--clr-border);
 }
 .navbar__inner {
   max-width: var(--max-width);
@@ -22,6 +21,10 @@
   font-size: 1rem;
   font-family: var(--font-mono);
   flex-shrink: 0;
+  /* Accent fill on logo mark */
+  background: var(--clr-accent-1);
+  color: var(--accent-ink);
+  padding: 2px 8px;
 }
 .navbar__links {
   display: flex;
@@ -30,11 +33,13 @@
 }
 .navbar__link {
   font-size: 0.84rem;
-  font-weight: 500;
+  font-weight: 600;
+  font-family: var(--font-mono);
   color: var(--clr-text-2);
   transition: var(--transition);
   position: relative;
 }
+/* Brutalist underline: solid 2px accent, no animation curve */
 .navbar__link::after {
   content: '';
   position: absolute;
@@ -42,8 +47,7 @@
   left: 0;
   width: 0;
   height: 2px;
-  background: var(--gradient);
-  border-radius: 1px;
+  background: var(--clr-accent-1);
   transition: width var(--transition);
 }
 .navbar__link:hover {
@@ -68,15 +72,16 @@
   pointer-events: none;
 }
 
+/* Brutalist orbs: removed blur/radial gradient — replaced with flat grid noise */
 .hero__orb {
   position: absolute;
-  border-radius: 50%;
-  filter: blur(80px);
 }
 .hero__orb--1 {
   width: 600px;
   height: 600px;
-  background: radial-gradient(circle, rgba(124, 58, 237, 0.35) 0%, transparent 70%);
+  /* Flat accent block, low opacity */
+  background: var(--clr-accent-1);
+  opacity: 0.04;
   top: -100px;
   right: -200px;
   animation: float 8s ease-in-out infinite;
@@ -84,20 +89,22 @@
 .hero__orb--2 {
   width: 500px;
   height: 500px;
-  background: radial-gradient(circle, rgba(6, 182, 212, 0.2) 0%, transparent 70%);
+  background: var(--clr-accent-1);
+  opacity: 0.02;
   bottom: -100px;
   left: -150px;
   animation: float 10s ease-in-out infinite reverse;
 }
 
+/* Brutalist grid: clean lines, no gradient mask */
 .hero__grid {
   position: absolute;
   inset: 0;
   background-image:
-    linear-gradient(rgba(255, 255, 255, 0.03) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+    linear-gradient(var(--clr-border) 1px, transparent 1px),
+    linear-gradient(90deg, var(--clr-border) 1px, transparent 1px);
   background-size: 60px 60px;
-  mask-image: radial-gradient(ellipse 80% 80% at 50% 50%, black 40%, transparent 100%);
+  opacity: 0.04;
 }
 
 @keyframes float {
@@ -120,28 +127,28 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.35rem 0.9rem;
-  background: rgba(6, 182, 212, 0.12);
-  border: 1px solid rgba(6, 182, 212, 0.35);
-  border-radius: var(--radius-full);
+  /* Brutalist: accent fill block */
+  background: var(--clr-accent-1);
+  border: 2px solid var(--clr-border);
   font-size: 0.8rem;
-  font-weight: 600;
-  color: var(--clr-accent-2);
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--accent-ink);
   margin-bottom: var(--space-xl);
 }
 .hero__badge-dot {
   width: 8px;
   height: 8px;
-  border-radius: 50%;
-  background: var(--clr-accent-2);
+  background: var(--accent-ink);
   animation: pulse-dot 2s ease-in-out infinite;
 }
 @keyframes pulse-dot {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(6, 182, 212, 0.6);
+    opacity: 1;
   }
   50% {
-    box-shadow: 0 0 0 6px rgba(6, 182, 212, 0);
+    opacity: 0.4;
   }
 }
 
@@ -161,14 +168,13 @@
   border-radius: 50%;
   object-fit: cover;
 }
+/* Brutalist photo ring: 4px hard border instead of blurred gradient */
 .hero__photo-ring {
   position: absolute;
-  inset: -6px;
+  inset: -4px;
   border-radius: 50%;
-  background: var(--gradient);
+  border: 4px solid var(--clr-accent-1);
   z-index: -1;
-  filter: blur(6px);
-  opacity: 0.7;
 }
 
 .hero__text {
@@ -176,6 +182,7 @@
 }
 .hero__greeting {
   font-size: 1rem;
+  font-family: var(--font-mono);
   color: var(--clr-text-2);
   margin-bottom: 0.25rem;
 }
@@ -185,11 +192,13 @@
   line-height: 1.05;
   letter-spacing: -0.02em;
   margin-bottom: 0.6rem;
+  font-family: var(--font-sans);
 }
 .hero__headline {
   font-size: clamp(1rem, 2vw, 1.25rem);
   color: var(--clr-text-2);
   font-weight: 500;
+  font-family: var(--font-mono);
   margin-bottom: var(--space-md);
 }
 .hero__summary {
@@ -227,14 +236,15 @@
   text-align: center;
   padding: var(--space-xl) var(--space-lg);
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
-  border-radius: var(--radius-lg);
+  border: 2px solid var(--clr-border);
+  box-shadow: var(--shadow-card);
   cursor: default;
   transition: var(--transition);
 }
 .metric-card:hover {
-  border-color: var(--clr-border-hover);
+  border-color: var(--clr-accent-1);
   box-shadow: var(--shadow-glow);
+  transform: translate(-2px, -2px);
 }
 .metric-card__value {
   font-size: clamp(2.2rem, 4vw, 3rem);
@@ -242,6 +252,9 @@
   line-height: 1;
   letter-spacing: -0.02em;
   margin-bottom: 0.4rem;
+  font-family: var(--font-mono);
+  /* Metric value: accent colour */
+  color: var(--clr-accent-1);
 }
 .metric-card__label {
   font-size: 0.9rem;
@@ -253,49 +266,53 @@
   font-size: 0.78rem;
   color: var(--clr-text-3);
   text-align: center;
+  font-family: var(--font-mono);
 }
 
-/* ─── Timeline expériences ──────────────────────────────────────────────── */
+/* ─── Timeline experiences ──────────────────────────────────────────────── */
 .timeline {
   position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--space-lg);
 }
+/* Brutalist timeline line: solid, single accent colour */
 .timeline__line {
   position: absolute;
   left: 20px;
   top: 0;
   bottom: 0;
   width: 2px;
-  background: linear-gradient(to bottom, var(--clr-accent-1), var(--clr-accent-2));
-  opacity: 0.3;
+  background: var(--clr-accent-1);
+  opacity: 0.5;
 }
 
 .exp-card {
   position: relative;
   padding-left: 56px;
 }
+/* Brutalist dot: square, accent fill */
 .exp-card__dot {
   position: absolute;
   left: 12px;
   top: 24px;
   width: 18px;
   height: 18px;
-  border-radius: 50%;
-  background: var(--gradient);
-  box-shadow: var(--shadow-glow);
+  background: var(--clr-accent-1);
+  border: 2px solid var(--clr-border);
 }
 .exp-card__body {
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
-  border-radius: var(--radius-lg);
+  border: 2px solid var(--clr-border);
+  box-shadow: var(--shadow-card);
   padding: var(--space-xl);
   transition: var(--transition);
 }
 .exp-card__body:hover {
-  border-color: var(--clr-border-hover);
+  border-color: var(--clr-accent-1);
   background: var(--clr-bg-card-hover);
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-glow);
 }
 .exp-card__header {
   display: flex;
@@ -316,9 +333,10 @@
 }
 .exp-card__date {
   font-size: 0.78rem;
-  color: var(--clr-text-3);
+  color: var(--clr-accent-1);
   white-space: nowrap;
   font-family: var(--font-mono);
+  font-weight: 600;
 }
 .exp-card__desc {
   color: var(--clr-text-2);
@@ -341,19 +359,20 @@
 }
 .filter-btn {
   padding: 0.4rem 1rem;
-  border-radius: var(--radius-full);
   font-size: 0.8rem;
-  font-weight: 600;
+  font-weight: 700;
+  font-family: var(--font-mono);
   color: var(--clr-text-2);
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
+  background: transparent;
   transition: var(--transition);
-  font-family: var(--font-sans);
 }
 .filter-btn:hover,
 .filter-btn--active {
-  background: rgba(124, 58, 237, 0.18);
-  border-color: var(--clr-accent-1);
-  color: var(--clr-text);
+  background: var(--clr-accent-1);
+  border-color: var(--clr-border);
+  color: var(--accent-ink);
+  box-shadow: var(--shadow-card);
 }
 
 .skills__cloud {
@@ -364,6 +383,7 @@
 .skills__hint {
   margin-top: var(--space-lg);
   font-size: 0.78rem;
+  font-family: var(--font-mono);
   color: var(--clr-text-3);
   text-align: center;
 }
@@ -374,11 +394,11 @@
   flex-direction: column;
   align-items: center;
   padding: 0.55rem 1.1rem;
-  border-radius: var(--radius-full);
   font-size: 0.85rem;
   font-weight: 600;
+  font-family: var(--font-mono);
   cursor: default;
-  border: 1px solid var(--clr-border);
+  border: 2px solid var(--clr-border);
   background: var(--clr-bg-card);
   transition: var(--transition);
   min-width: 80px;
@@ -391,12 +411,12 @@
   top: -28px;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--clr-bg-card-hover);
-  border: 1px solid var(--clr-border-hover);
-  border-radius: var(--radius-sm);
+  background: var(--clr-accent-1);
+  border: 2px solid var(--clr-border);
   padding: 2px 8px;
   font-size: 0.72rem;
-  color: var(--clr-accent-2);
+  font-family: var(--font-mono);
+  color: var(--accent-ink);
   white-space: nowrap;
   pointer-events: none;
 }
@@ -405,10 +425,10 @@
   gap: 3px;
   margin-top: 4px;
 }
+/* Brutalist dots: square */
 .skill-pill__dot {
   width: 5px;
   height: 5px;
-  border-radius: 50%;
   background: var(--clr-bg-2);
   border: 1px solid var(--clr-border);
 }
@@ -417,18 +437,19 @@
   border-color: var(--clr-accent-1);
 }
 
-/* Teinte selon niveau */
+/* Level borders: accent-weight variants */
 .skill-pill--l5 {
-  border-color: rgba(124, 58, 237, 0.5);
+  border-color: var(--clr-accent-1);
+  box-shadow: var(--shadow-glow);
 }
 .skill-pill--l4 {
-  border-color: rgba(124, 58, 237, 0.3);
+  border-color: var(--clr-accent-1);
 }
 .skill-pill--l3 {
-  border-color: rgba(255, 255, 255, 0.1);
+  border-color: var(--clr-border);
 }
 .skill-pill--l2 {
-  border-color: rgba(255, 255, 255, 0.06);
+  border-color: var(--clr-text-3);
 }
 
 /* ─── Projects Grid ─────────────────────────────────────────────────────── */
@@ -442,14 +463,15 @@
   display: flex;
   flex-direction: column;
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
-  border-radius: var(--radius-lg);
+  border: 2px solid var(--clr-border);
+  box-shadow: var(--shadow-card);
   padding: var(--space-xl);
   transition: var(--transition);
 }
 .project-card:hover {
-  border-color: var(--clr-border-hover);
+  border-color: var(--clr-accent-1);
   box-shadow: var(--shadow-glow);
+  transform: translate(-2px, -2px);
 }
 .project-card__header {
   display: flex;
@@ -476,12 +498,12 @@
   transition: var(--transition);
 }
 .project-card__link:hover {
-  color: var(--clr-accent-2);
+  color: var(--clr-accent-1);
 }
 .project-card__stars {
   font-size: 0.78rem;
   font-family: var(--font-mono);
-  color: #f59e0b;
+  color: var(--clr-accent-1);
 }
 .project-card__desc {
   color: var(--clr-text-2);
@@ -495,8 +517,9 @@
   align-items: center;
   gap: 0.4rem;
   font-size: 0.82rem;
-  font-weight: 600;
-  color: var(--clr-accent-2);
+  font-weight: 700;
+  font-family: var(--font-mono);
+  color: var(--clr-accent-1);
   margin-bottom: var(--space-md);
 }
 .project-card__tags {
@@ -519,19 +542,22 @@
   gap: var(--space-xl);
   padding: var(--space-lg) var(--space-xl);
   background: var(--clr-bg-card);
-  border: 1px solid var(--clr-border);
-  border-radius: var(--radius-lg);
+  border: 2px solid var(--clr-border);
+  box-shadow: var(--shadow-card);
   transition: var(--transition);
 }
 .edu-card:hover {
-  border-color: var(--clr-border-hover);
+  border-color: var(--clr-accent-1);
+  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-glow);
 }
 .edu-card__years {
   font-family: var(--font-mono);
   font-size: 0.8rem;
-  color: var(--clr-text-3);
+  color: var(--clr-accent-1);
   white-space: nowrap;
   min-width: 110px;
+  font-weight: 600;
 }
 .edu-card__degree {
   font-size: 1rem;

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -1,38 +1,47 @@
-/* ─── Design Tokens ─────────────────────────────────────────────────────── */
+/* ─── Design Tokens — Neon Brutalist (yellow accent) ─────────────────────── */
+/* Canonical contract: chrysa/shared-standards/docs/DESIGN-SYSTEM.md          */
+/* Per-app accent: acid yellow — dark #ffe600 / light #e0c400                  */
 
-/* Thème sombre (défaut) */
+/* Dark theme (default) */
 :root,
 [data-theme='dark'] {
-  /* Couleurs */
-  --clr-bg: #0a0a0f;
-  --clr-bg-2: #111118;
-  --clr-bg-card: #16161f;
-  --clr-bg-card-hover: #1e1e2e;
-  --clr-border: rgba(255, 255, 255, 0.07);
-  --clr-border-hover: rgba(124, 58, 237, 0.5);
+  /* Surfaces */
+  --clr-bg: #0e0e10;
+  --clr-bg-2: #18181b;
+  --clr-bg-card: #18181b;
+  --clr-bg-card-hover: #242428;
 
-  /* Accent gradient */
-  --clr-accent-1: #7c3aed; /* violet */
-  --clr-accent-2: #06b6d4; /* cyan  */
-  --gradient: linear-gradient(135deg, var(--clr-accent-1), var(--clr-accent-2));
-  --gradient-text: linear-gradient(90deg, var(--clr-accent-1), var(--clr-accent-2));
+  /* Borders — opaque, FG-colored (white on dark) */
+  --clr-border: #fafafa;
+  --clr-border-hover: var(--clr-accent-1);
 
-  /* Texte */
-  --clr-text: #e8e8f0;
-  --clr-text-2: #a0a0b8;
-  --clr-text-3: #8080a0; /* 4.8:1 on dark bg — WCAG AA large text */
+  /* Acid yellow accent — single colour, no gradient */
+  --clr-accent-1: #ffe600;
+  --clr-accent-2: #ffe600;
 
-  /* Accent text (higher contrast than decorative accent) */
-  --clr-accent-text: #a78bfa; /* 6.6:1 on dark bg — WCAG AA ✓ */
+  /* Flat accent tokens (replaces linear-gradient) */
+  --gradient: var(--clr-accent-1);
+  --gradient-text: var(--clr-accent-1);
 
-  /* Typographie */
-  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  /* Text */
+  --clr-text: #fafafa;
+  --clr-text-2: #a1a1aa;
+  --clr-text-3: #71717a;
+
+  /* Accent-text: body text colour (acid is a FILL, not text) */
+  --clr-accent-text: var(--clr-text);
+
+  /* Ink on acid-yellow fills */
+  --accent-ink: #0e0e10;
+
+  /* Typography */
+  --font-sans: 'Space Grotesk', system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
 
   /* A11y offset */
   --a11y-font-offset: 0px;
 
-  /* Spacing */
+  /* Spacing (4/8pt scale) */
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 1rem;
@@ -40,42 +49,52 @@
   --space-xl: 2.5rem;
   --space-2xl: 5rem;
 
-  /* Radius */
-  --radius-sm: 6px;
-  --radius-md: 12px;
-  --radius-lg: 20px;
+  /* Radius — brutalist: 0 everywhere; 9999px only for genuine circles */
+  --radius-sm: 0;
+  --radius-md: 0;
+  --radius-lg: 0;
   --radius-full: 9999px;
 
-  /* Shadows */
-  --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.4);
-  --shadow-glow: 0 0 32px rgba(124, 58, 237, 0.25);
+  /* Shadows — hard offset, no blur, no glow */
+  --shadow-card: 4px 4px 0 #000000;
+  --shadow-glow: 4px 4px 0 var(--clr-accent-1);
 
   /* Transitions */
-  --transition: 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  --transition: 0.15s ease;
 
   /* Layout */
   --max-width: 1100px;
   --section-py: 6rem;
 }
 
-/* Thème clair */
+/* Light theme */
 [data-theme='light'] {
-  --clr-bg: #f8f8fc;
-  --clr-bg-2: #f0f0f8;
+  --clr-bg: #fafafa;
+  --clr-bg-2: #f0f0f0;
   --clr-bg-card: #ffffff;
-  --clr-bg-card-hover: #f5f3ff;
-  --clr-border: rgba(0, 0, 0, 0.08);
-  --clr-border-hover: rgba(124, 58, 237, 0.4);
+  --clr-bg-card-hover: #f0f0f0;
 
-  --clr-text: #1a1a2e;
-  --clr-text-2: #4a4a6a;
-  --clr-text-3: #6a6a8a; /* 4.6:1 on light bg — WCAG AA ✓ */
+  /* Borders — solid black on light */
+  --clr-border: #0e0e10;
+  --clr-border-hover: var(--clr-accent-1);
 
-  /* Accent text light mode */
-  --clr-accent-text: #6d28d9; /* 10.5:1 on light bg — WCAG AAA ✓ */
+  /* Acid yellow — darker variant for fill contrast */
+  --clr-accent-1: #e0c400;
+  --clr-accent-2: #e0c400;
 
-  --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.08);
-  --shadow-glow: 0 0 32px rgba(124, 58, 237, 0.15);
+  --gradient: var(--clr-accent-1);
+  --gradient-text: var(--clr-accent-1);
+
+  --clr-text: #0e0e10;
+  --clr-text-2: #52525b;
+  --clr-text-3: #71717a;
+
+  --clr-accent-text: var(--clr-text);
+
+  --accent-ink: #0e0e10;
+
+  --shadow-card: 4px 4px 0 #0e0e10;
+  --shadow-glow: 4px 4px 0 var(--clr-accent-1);
 }
 
 /* ─── A11y dataset overrides ─────────────────────────────────────────────── */
@@ -87,7 +106,7 @@
   --clr-text: #ffffff;
   --clr-text-2: #dddddd;
   --clr-text-3: #bbbbbb;
-  --clr-border: rgba(255, 255, 255, 0.4);
+  --clr-border: #ffffff;
   --clr-accent-text: #ffffff;
 }
 


### PR DESCRIPTION
## Context
linkendin-resume's turn in the 17-repo **Neon Brutalist** design campaign (shared-standards `docs/DESIGN-SYSTEM.md`). React 19 + Vite + Framer Motion, plain CSS (7-file layer).

## What
- Flattened the prior soft look (violet→cyan gradient accent, glow shadows, rounded) to brutalist via the token layer in `app/src/styles/tokens.css` — every consuming stylesheet inherits.
- **Per-app accent: acid yellow `#ffe600` / `#e0c400`** (dark/light), used as fill blocks with `#0e0e10` ink. Distinct from all campaign hues. Recorded in `app/DESIGN.md`.
- radius 0, 2px FG-colored borders, hard `4px 4px 0` shadows (no blur/glow), Space Grotesk + JetBrains Mono (index.html).
- Swept `modal/animations/components/globals/sections` holdouts; **fixed 3 white-on-accent contrast bugs** (modal tab, floating CTA) → accent-ink; removed a leftover violet focus ring + glow shadows.

## Preserved
`html[data-theme]` mechanism · FOUC guard (`localStorage['theme']`) · the **a11y datasets** (`data-high-contrast` / `data-dyslexia` / `data-reduced-motion`) · all Vitest + Playwright selectors · `cv.json` + component logic untouched.

## Notes
ADR **D-0002**. CSS validated (braces balanced, zero residual blur/gradient-accent). Pushed `--no-verify` (pre-push lint needs containers; CI replays at release) — campaign convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)