### PR TITLE
design(frontend): migrate to Editorial persona (warm amber) — persona pilot

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -32,7 +32,7 @@ No active deviation is in effect. Any future deviation must be added as a new AD
 ## D-0002 — Adopt Neon Brutalist design system (yellow accent)
 
 - **Date:** 2026-06-12
-- **Status:** Accepted
+- **Status:** Superseded by D-0003
 - **Context:** linkendin-resume's turn in the 17-repo design campaign rolling out
   the shared-standards Neon Brutalist system. The prior look was soft (violet→cyan
   gradient accent, glow shadows, rounded) — the opposite of the chosen DNA.
@@ -47,3 +47,28 @@ No active deviation is in effect. Any future deviation must be added as a new AD
   `data-reduced-motion` accessibility datasets are all preserved. All Vitest +
   Playwright test selectors are unchanged; `cv.json` and component logic untouched.
   See `app/DESIGN.md`.
+
+---
+
+## D-0003 — Adopt Editorial persona (supersedes brutalist D-0002; persona-migration pilot)
+
+- **Date:** 2026-06-12
+- **Status:** Accepted
+- **Context:** linkendin-resume selected as the pilot for the chrysa persona
+  migration to the Editorial system defined in `shared-standards/docs/DESIGN-SYSTEM.md
+  §1 Editorial` and accent-restraint rules `§4`. The Neon Brutalist look (D-0002 —
+  radius 0, 2px FG borders, hard offset shadows, acid fill blocks, mono-only type,
+  Space Grotesk) was reversed in favour of a crafted, readable résumé aesthetic.
+- **Decision:** Tokens updated to warm amber accent (`#f0a830` dark / `#b45309`
+  light), Fraunces serif display + Inter body, soft `10px` radius, `0 4px 24px`
+  blurred shadows, 1px hairline borders, calm 0.22s transitions. Swept all six
+  consuming stylesheets (`globals`, `components`, `sections`, `modal`,
+  `animations`, `responsive`) — serif headings, soft rounded cards/buttons,
+  1px hairline borders, normal case labels, amber restrained to one CTA fill +
+  amber-text links. Press-translate hover effects replaced by calm `translateY`
+  lifts or `brightness` filters.
+- **Consequences:** `data-theme` dark/light mechanism, FOUC guard, and the
+  `data-high-contrast` / `data-dyslexia` / `data-reduced-motion` a11y datasets
+  all preserved and working. All Vitest + Playwright test selectors (`data-testid`,
+  `role`, `aria-*`) are unchanged. `cv.json` and component logic untouched. See
+  `app/DESIGN.md`.

--- a/app/DESIGN.md
+++ b/app/DESIGN.md
@@ -1,25 +1,40 @@
 # Design — linkendin-resume (cv-online)
 
-This frontend follows the chrysa **Neon Brutalist** design system:
-[`shared-standards/docs/DESIGN-SYSTEM.md`](https://github.com/chrysa/shared-standards/blob/main/docs/DESIGN-SYSTEM.md).
+This frontend follows the chrysa **Editorial** design persona:
+[`shared-standards/docs/DESIGN-SYSTEM.md §1 Editorial`](https://github.com/chrysa/shared-standards/blob/main/docs/DESIGN-SYSTEM.md)
+and accent-restraint rules from `§4 Accent`.
 
-## Aesthetic
+## Persona
 
-Loud structure, flat fills, one acid accent. Radius `0`, 2px FG-colored borders
-(white on dark / black on light), hard offset shadows (`4px 4px 0`), **no
-gradients, no glow**, mono-forward type.
+`data-persona="editorial"` is set on `<html>` in `app/index.html`.
 
-## Per-app accent
+Editorial reads as an elegant, readable résumé piece. The differentiator is
+the Fraunces serif for all display headings combined with Inter for body text
+— that contrast signals "crafted document" rather than "generic web app".
+Spacing is generous, cards are softly rounded, and the warm amber accent is
+used sparingly: one primary CTA fill, amber text for links and section kickers,
+never large acid fill blocks.
 
-**Acid yellow** — `#ffe600` (dark) · `#e0c400` (light, darker variant for fill
-contrast). Used only as **fill blocks** with `--accent-ink` (`#0e0e10`) text,
-never as acid text on the background. Distinct from every other campaign hue
-(lime/cyan/violet/orange/magenta/azure).
+## Accent
 
-## Type
+**Warm amber** — dark theme `#f0a830` / light theme `#b45309` (darker for
+contrast on white). Used only as:
 
-- Display / body: **Space Grotesk** (`--font-sans`)
-- Mono (labels, dates, tech tags, metrics): **JetBrains Mono** (`--font-mono`)
+- `background` on the **one primary CTA** button (`.btn--primary`) and the
+  Ask Me trigger / send button.
+- `color` on links, section eyebrows (`.section__label`), dates, metric values,
+  and the `--clr-accent-text` token.
+- Never as a large fill block filling headers, badges, nav logos, or filter tabs.
+
+## Typography
+
+- **Display / headings**: `Fraunces` (serif, optical sizes) — `--font-display`.
+  Applied to: hero name, section titles, card titles, exp/edu/modal titles,
+  metric values, contact section title, projects sub-titles.
+- **Body / UI**: `Inter` — `--font-sans`. Applied to body text, nav links,
+  buttons, labels, form fields.
+- **Mono / data**: `JetBrains Mono` — `--font-mono`. Applied to dates, section
+  eyebrow kickers, tech tags, metric sub-labels, terminal.
 
 Loaded via Google Fonts in `app/index.html`.
 
@@ -30,17 +45,28 @@ stylesheet (`globals`, `components`, `sections`, `modal`, `animations`,
 `responsive`) reads its CSS custom properties, so re-theming happens in one
 place.
 
+Key Editorial token values:
+
+- `--radius-sm: 8px` / `--radius-md: 10px` / `--radius-lg: 14px` / `--radius-full: 9999px`
+- `--shadow-card: 0 4px 24px rgb(0 0 0 / 0.18)` (soft blurred, no hard offset)
+- `--border-weight: 1px` (hairline — never 2px FG-colored)
+- `--transition: 0.22s ease` (calm motion)
+
 ## Theme mechanism (preserved)
 
 - `data-theme="dark" | "light"` on `<html>`, set by the FOUC guard in
   `index.html` from `localStorage['theme']` and `prefers-color-scheme`, managed
   at runtime by `useTheme` / `ThemeProvider`.
 - **Accessibility datasets** are preserved and still drive token overrides:
-  `data-high-contrast`, `data-dyslexia`, `data-reduced-motion`.
+  - `data-high-contrast` — increases contrast on borders and text
+  - `data-dyslexia` — switches `--font-sans` to OpenDyslexic
+  - `data-reduced-motion` — collapses all animation/transition durations to 0.01ms
 
 ## Constraints honoured
 
-- WCAG 2.1 AA in both themes; yellow accent fills carry `#0e0e10` ink.
+- WCAG 2.1 AA in both themes; amber on dark `#f0a830` / `#0e0e10` meets 7:1.
+  Amber on light `#b45309` on `#fafafa` meets 4.8:1 (AA).
 - All test selectors (`data-testid`, roles, aria-labels, ids/classes queried by
   Vitest + Playwright) are unchanged — this was a restyle only.
 - Content remains data-driven from `app/cv.json`; no component logic changed.
+- Skip-nav, i18n, and keyboard navigation are unaffected.

--- a/app/index.html
+++ b/app/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="fr" data-persona="editorial">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -28,8 +28,8 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <!-- Neon Brutalist type — Space Grotesk (display) + JetBrains Mono -->
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet" />
+    <!-- Editorial persona — Fraunces (serif display) + Inter (body) + JetBrains Mono -->
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
     <script>
       (function () {
         var t = localStorage.getItem('theme');

--- a/app/src/styles/animations.css
+++ b/app/src/styles/animations.css
@@ -4,11 +4,12 @@
   top: 0;
   left: 0;
   right: 0;
-  height: 3px;
+  height: 2px;
   background: var(--clr-accent-1);
   transform-origin: left;
   z-index: 9999;
   pointer-events: none;
+  opacity: 0.8;
 }
 
 /* ─── Custom Cursor ─────────────────────────────────────────────────────── */
@@ -25,6 +26,7 @@
 }
 
 /* ─── Floating CTA ──────────────────────────────────────────────────────── */
+/* Editorial floating CTA: the ONE amber fill CTA — soft rounded, no hard border-radius:0 */
 .floating-cta {
   position: fixed;
   bottom: 2rem;
@@ -37,13 +39,17 @@
   background: var(--clr-accent-1);
   color: var(--accent-ink);
   font-family: var(--font-sans);
-  font-weight: 700;
+  font-weight: 600;
   font-size: 0.9rem;
-  border: 2px solid var(--clr-border);
-  border-radius: 0;
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
   box-shadow: var(--shadow-card);
   cursor: pointer;
   transition: var(--transition);
+}
+.floating-cta:hover {
+  filter: brightness(1.08);
+  box-shadow: var(--shadow-card);
 }
 
 .floating-cta i {
@@ -56,18 +62,19 @@
   }
   .floating-cta {
     padding: 0.85rem;
-    border-radius: 0;
+    border-radius: var(--radius-md);
   }
 }
 
 /* ─── Skill Tooltip ─────────────────────────────────────────────────────── */
+/* Editorial tooltip: soft card, 1px hairline */
 .skill-tooltip {
   position: absolute;
   bottom: calc(100% + 0.6rem);
   left: 50%;
   transform: translateX(-50%);
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   border-radius: var(--radius-md);
   padding: 0.7rem 0.9rem;
   min-width: 160px;
@@ -77,11 +84,11 @@
   white-space: nowrap;
 }
 
+/* Editorial tooltip level: mono eyebrow, amber text, normal-ish tracking */
 .skill-tooltip__level {
   font-size: 0.72rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  font-weight: 600;
+  letter-spacing: 0.06em;
   color: var(--clr-accent-text);
   margin-bottom: 0.4rem;
   font-family: var(--font-mono);

--- a/app/src/styles/components.css
+++ b/app/src/styles/components.css
@@ -14,6 +14,7 @@
 
 /* ─── Accessibility Panel ─────────────────────────────────────────────── */
 
+/* Editorial a11y trigger: soft circle, 1px hairline */
 .a11y-trigger {
   position: fixed;
   bottom: 5.5rem;
@@ -21,9 +22,9 @@
   z-index: 200;
   width: 2.8rem;
   height: 2.8rem;
-  /* Brutalist: square, 2px border, hard shadow */
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-md);
   color: var(--clr-text-2);
   display: flex;
   align-items: center;
@@ -38,15 +39,16 @@
 }
 .a11y-trigger:hover,
 .a11y-trigger[aria-expanded='true'] {
-  background: var(--clr-accent-1);
-  color: var(--accent-ink);
-  border-color: var(--clr-border);
+  background: var(--clr-bg-card-hover);
+  color: var(--clr-accent-text);
+  border-color: var(--clr-accent-1);
 }
 .a11y-trigger:focus-visible {
   outline: 2px solid var(--clr-accent-1);
   outline-offset: 2px;
 }
 
+/* Editorial a11y panel: soft card, 1px hairline */
 .a11y-panel {
   position: fixed;
   bottom: 9rem;
@@ -54,7 +56,8 @@
   z-index: 200;
   width: 280px;
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-card);
   padding: 1.25rem;
   display: flex;
@@ -62,11 +65,12 @@
   gap: 1rem;
 }
 
+/* Editorial a11y title: mono eyebrow, amber text, no fill block */
 .a11y-panel__title {
-  font-size: 0.75rem;
-  font-weight: 700;
+  font-size: 0.72rem;
+  font-weight: 600;
   font-family: var(--font-mono);
-  color: var(--clr-accent-1);
+  color: var(--clr-accent-text);
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
@@ -98,12 +102,13 @@
   font-family: var(--font-mono);
 }
 
+/* Editorial step btn: soft radius, 1px hairline */
 .a11y-step-btn {
   width: 1.6rem;
   height: 1.6rem;
-  /* Brutalist: square, 2px border */
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-sm);
   color: var(--clr-text);
   cursor: pointer;
   display: flex;
@@ -112,9 +117,9 @@
   transition: background var(--transition);
 }
 .a11y-step-btn:hover {
-  background: var(--clr-accent-1);
-  color: var(--accent-ink);
-  border-color: var(--clr-border);
+  background: var(--clr-bg-card-hover);
+  color: var(--clr-accent-text);
+  border-color: var(--clr-accent-1);
 }
 .a11y-step-btn:disabled {
   opacity: 0.35;
@@ -125,7 +130,7 @@
   outline-offset: 1px;
 }
 
-/* Toggle switch */
+/* Toggle switch — pill track, rounded thumb */
 .a11y-toggle {
   display: flex;
   align-items: center;
@@ -136,9 +141,9 @@
 .a11y-toggle__track {
   width: 2.4rem;
   height: 1.35rem;
-  /* Brutalist: square track */
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-full);
   position: relative;
   transition: background var(--transition);
   flex-shrink: 0;
@@ -150,7 +155,7 @@
   left: 2px;
   width: 0.9rem;
   height: 0.9rem;
-  /* Square thumb */
+  border-radius: 50%;
   background: var(--clr-text-2);
   transition:
     transform var(--transition),
@@ -158,7 +163,7 @@
 }
 .a11y-toggle[aria-pressed='true'] .a11y-toggle__track {
   background: var(--clr-accent-1);
-  border-color: var(--clr-border);
+  border-color: var(--clr-accent-1);
 }
 .a11y-toggle[aria-pressed='true'] .a11y-toggle__track::after {
   transform: translateX(1.05rem);
@@ -173,24 +178,27 @@
   outline-offset: 2px;
 }
 
+/* Editorial reset button: soft radius, 1px hairline */
 .a11y-reset {
   width: 100%;
   padding: 0.45rem 0.75rem;
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-md);
   color: var(--clr-text-2);
   font-size: 0.82rem;
   cursor: pointer;
   text-align: center;
   transition:
     background var(--transition),
-    color var(--transition);
+    color var(--transition),
+    border-color var(--transition);
   font-family: var(--font-sans);
 }
 .a11y-reset:hover {
-  background: var(--clr-accent-1);
-  color: var(--accent-ink);
-  border-color: var(--clr-border);
+  background: var(--clr-bg-card-hover);
+  color: var(--clr-accent-text);
+  border-color: var(--clr-accent-1);
 }
 .a11y-reset:focus-visible {
   outline: 2px solid var(--clr-accent-1);
@@ -206,6 +214,7 @@
   background: rgba(0, 0, 0, 0.8);
 }
 
+/* Terminal: stays with its own mono aesthetic — slight radius for Editorial softness */
 .terminal {
   position: fixed;
   top: 50%;
@@ -215,8 +224,8 @@
   width: min(640px, 96vw);
   height: min(400px, 85vh);
   background: #0d1117;
-  /* Brutalist: 2px border, hard shadow */
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-md);
   box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
@@ -230,7 +239,7 @@
   gap: 0.5rem;
   padding: 0.6rem 1rem;
   background: #161b22;
-  border-bottom: 2px solid var(--clr-border);
+  border-bottom: 1px solid var(--clr-border);
   user-select: none;
   flex-shrink: 0;
 }
@@ -290,7 +299,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.6rem 1rem;
-  border-top: 2px solid var(--clr-border);
+  border-top: 1px solid var(--clr-border);
   background: #0d1117;
   flex-shrink: 0;
 }
@@ -322,6 +331,7 @@
   background: rgba(0, 0, 0, 0.7);
 }
 
+/* Editorial palette: soft card, 1px hairline */
 .palette {
   position: fixed;
   top: 12vh;
@@ -331,7 +341,8 @@
   width: min(600px, 96vw);
   max-height: 70vh;
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-card);
   overflow: hidden;
   display: flex;
@@ -343,7 +354,7 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.9rem 1rem;
-  border-bottom: 2px solid var(--clr-border);
+  border-bottom: 1px solid var(--clr-border);
   flex-shrink: 0;
 }
 
@@ -367,11 +378,13 @@
   color: var(--clr-text-3);
 }
 
+/* Editorial esc badge: soft pill, 1px hairline */
 .palette__esc {
   font-size: 0.7rem;
   color: var(--clr-text-3);
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-sm);
   padding: 0.15rem 0.4rem;
   font-family: var(--font-mono);
   flex-shrink: 0;
@@ -396,14 +409,15 @@
   padding: 0.25rem 0;
 }
 
+/* Editorial group label: mono eyebrow, amber text — no fill */
 .palette__group-label {
   padding: 0.3rem 1rem;
   font-size: 0.72rem;
-  font-weight: 700;
+  font-weight: 600;
   font-family: var(--font-mono);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: var(--clr-accent-1);
+  color: var(--clr-accent-text);
 }
 
 .palette__item {
@@ -421,11 +435,13 @@
   cursor: pointer;
   transition: background var(--transition);
 }
+/* Editorial item hover: surface tint + amber left accent line (1px, not 4px) */
 .palette__item:hover,
 .palette__item--selected {
   background: var(--clr-bg-card-hover);
   color: var(--clr-text);
-  border-left: 4px solid var(--clr-accent-1);
+  border-left: 2px solid var(--clr-accent-1);
+  padding-left: calc(1rem - 1px);
 }
 .palette__item:focus-visible {
   outline: 2px solid var(--clr-accent-1);
@@ -442,23 +458,26 @@
   color: var(--clr-accent-1);
 }
 
+/* Editorial palette footer: 1px hairline */
 .palette__footer {
   display: flex;
   align-items: center;
   gap: 1.25rem;
   padding: 0.55rem 1rem;
-  border-top: 2px solid var(--clr-border);
+  border-top: 1px solid var(--clr-border);
   font-size: 0.72rem;
   color: var(--clr-text-3);
   flex-shrink: 0;
   background: var(--clr-bg-2);
 }
 
+/* Editorial kbd: soft radius, 1px hairline */
 kbd {
   display: inline-block;
   padding: 0.1em 0.35em;
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-sm);
   font-family: var(--font-mono);
   font-size: 0.72rem;
   line-height: 1.4;
@@ -467,10 +486,12 @@ kbd {
 
 /* ─── GitHub graph + skeleton ─────────────────────────────────────────── */
 
+/* Editorial github graph: soft card, 1px hairline */
 .github-graph {
   margin: 2rem 0;
   overflow: hidden;
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-md);
   background: var(--clr-bg-card);
   padding: 1rem;
   text-align: center;
@@ -487,21 +508,23 @@ kbd {
   margin-bottom: var(--space-xl);
 }
 
+/* Editorial sub-title: serif heading */
 .projects__sub-title {
   font-size: clamp(1.1rem, 2vw, 1.3rem);
-  font-weight: 700;
+  font-weight: 600;
   color: var(--clr-text);
   margin: 0 0 1.25rem;
-  font-family: var(--font-mono);
+  font-family: var(--font-display);
 }
 
 .project-card--skeleton {
   pointer-events: none;
 }
 
-/* Skeleton: brutalist flat shimmer, no gradient */
+/* Skeleton shimmer */
 .skeleton {
   background: var(--clr-bg-card-hover);
+  border-radius: var(--radius-sm);
   animation: skeleton-shimmer 1.5s ease-in-out infinite;
   height: 1rem;
 }
@@ -533,6 +556,7 @@ kbd {
 
 /* ─── Ask Me Widget ───────────────────────────────────────────────────── */
 
+/* Ask me trigger: the ONE amber CTA, soft rounded */
 .askme-trigger {
   position: fixed;
   bottom: 1.5rem;
@@ -540,22 +564,29 @@ kbd {
   z-index: 200;
   width: 3rem;
   height: 3rem;
-  /* Brutalist: square, accent fill, 2px border */
   background: var(--clr-accent-1);
-  border: 2px solid var(--clr-border);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
   color: var(--accent-ink);
   font-size: 1.3rem;
   display: flex;
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  box-shadow: var(--shadow-glow);
+  box-shadow: var(--shadow-card);
+  transition:
+    filter var(--transition),
+    box-shadow var(--transition);
+}
+.askme-trigger:hover {
+  filter: brightness(1.08);
 }
 .askme-trigger:focus-visible {
   outline: 2px solid var(--clr-accent-1);
   outline-offset: 3px;
 }
 
+/* Editorial askme panel: soft card, 1px hairline */
 .askme-panel {
   position: fixed;
   bottom: 5.5rem;
@@ -563,7 +594,8 @@ kbd {
   z-index: 200;
   width: min(340px, 96vw);
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-lg);
   box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
@@ -574,17 +606,18 @@ kbd {
   display: flex;
   align-items: center;
   padding: 0.75rem 1rem;
-  border-bottom: 2px solid var(--clr-border);
+  border-bottom: 1px solid var(--clr-border);
   background: var(--clr-bg-2);
   flex-shrink: 0;
 }
 
+/* Editorial panel title: serif, normal case */
 .askme-panel__title {
   flex: 1;
   font-size: 0.9rem;
-  font-weight: 700;
+  font-weight: 600;
   color: var(--clr-text);
-  font-family: var(--font-mono);
+  font-family: var(--font-display);
 }
 
 .askme-panel__close {
@@ -618,21 +651,23 @@ kbd {
   scrollbar-color: var(--clr-border) transparent;
 }
 
+/* Editorial message bubbles: soft radius, 1px hairline */
 .askme-msg {
   max-width: 85%;
   padding: 0.55rem 0.85rem;
   font-size: 0.85rem;
   line-height: 1.5;
   word-break: break-word;
-  /* Brutalist: sharp corner */
-  border: 2px solid var(--clr-border);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--clr-border);
 }
 
+/* User message: amber tint, reserved for this one context */
 .askme-msg--user {
   align-self: flex-end;
   background: var(--clr-accent-1);
   color: var(--accent-ink);
-  border-color: var(--clr-border);
+  border-color: transparent;
 }
 
 .askme-msg--assistant {
@@ -652,7 +687,7 @@ kbd {
 .askme-msg--typing span {
   width: 6px;
   height: 6px;
-  /* Square dots: brutalist */
+  border-radius: 50%;
   background: var(--clr-text-3);
   animation: typing-bounce 1.2s infinite;
 }
@@ -679,14 +714,16 @@ kbd {
   align-items: center;
   gap: 0.5rem;
   padding: 0.6rem 0.75rem;
-  border-top: 2px solid var(--clr-border);
+  border-top: 1px solid var(--clr-border);
   flex-shrink: 0;
 }
 
+/* Editorial input: soft radius, 1px hairline */
 .askme-panel__input {
   flex: 1;
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-md);
   padding: 0.45rem 0.75rem;
   color: var(--clr-text);
   font-size: 0.85rem;
@@ -701,11 +738,13 @@ kbd {
   color: var(--clr-text-3);
 }
 
+/* Send button: amber fill, soft radius */
 .askme-panel__send {
   width: 2rem;
   height: 2rem;
   background: var(--clr-accent-1);
-  border: 2px solid var(--clr-border);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
   color: var(--accent-ink);
   font-size: 0.9rem;
   display: flex;
@@ -713,7 +752,7 @@ kbd {
   justify-content: center;
   cursor: pointer;
   transition:
-    opacity var(--transition),
+    filter var(--transition),
     box-shadow var(--transition);
   flex-shrink: 0;
 }
@@ -722,7 +761,8 @@ kbd {
   cursor: not-allowed;
 }
 .askme-panel__send:hover:not(:disabled) {
-  box-shadow: var(--shadow-glow);
+  filter: brightness(1.08);
+  box-shadow: var(--shadow-card);
 }
 .askme-panel__send:focus-visible {
   outline: 2px solid var(--clr-accent-1);
@@ -730,7 +770,7 @@ kbd {
 }
 
 /* ─── Hero headline glitch ─────────────────────────────────────────────── */
-
+/* Retained: functional motion (name typing/update feedback) */
 .hero__headline--glitch {
   animation: glitch 0.4s steps(2, jump-none);
 }

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -58,10 +58,11 @@ button {
 }
 
 /* ─── Accessibilite — Focus visible ─────────────────────────────────────── */
-/* Brutalist focus: 2px offset outline in accent, no radius */
+/* Editorial focus: 2px offset outline in accent, softly rounded */
 :focus-visible {
   outline: 2px solid var(--clr-accent-1);
   outline-offset: 3px;
+  border-radius: var(--radius-sm);
 }
 
 /* ─── Accessibilite — Skip Nav ──────────────────────────────────────────── */
@@ -77,8 +78,9 @@ button {
   font-size: 0.9rem;
   text-decoration: none;
   transition: top 0.2s;
-  /* Brutalist: no radius, 2px border */
-  border: 2px solid var(--clr-border);
+  /* Editorial: soft radius, 1px hairline border */
+  border-radius: var(--radius-md);
+  border: 1px solid var(--clr-border);
 }
 .skip-nav:focus {
   top: var(--space-md);
@@ -94,17 +96,19 @@ button {
   padding: 0 var(--space-xl);
 }
 
-/* gradient-text: brutalist — solid accent colour, no background-clip trick */
+/* gradient-text: Editorial — solid accent colour */
 .gradient-text {
   color: var(--clr-accent-1);
 }
 
+/* Editorial tag/chip: soft pill shape, 1px hairline, amber text on surface */
 .tag {
   display: inline-block;
   padding: 2px 10px;
-  background: var(--clr-accent-1);
-  color: var(--accent-ink);
-  border: 2px solid var(--clr-border);
+  background: var(--clr-bg-card);
+  color: var(--clr-accent-text);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-full);
   font-size: 0.75rem;
   font-family: var(--font-mono);
   white-space: nowrap;
@@ -117,34 +121,37 @@ button {
   gap: var(--space-sm);
   padding: 0.65rem 1.4rem;
   font-size: 0.9rem;
-  font-weight: 700;
+  font-weight: 600;
   transition: var(--transition);
   font-family: var(--font-sans);
   cursor: pointer;
-  /* Brutalist: no radius, 2px border */
-  border: 2px solid var(--clr-border);
+  /* Editorial: soft radius, 1px hairline border */
+  border-radius: var(--radius-md);
+  border: 1px solid var(--clr-border);
 }
 
+/* Primary CTA: the ONE amber fill button */
 .btn--primary {
   background: var(--clr-accent-1);
   color: var(--accent-ink);
-  border-color: var(--clr-border);
-  box-shadow: var(--shadow-glow);
+  border-color: transparent;
+  box-shadow: var(--shadow-card);
 }
 .btn--primary:hover {
+  filter: brightness(1.08);
   box-shadow: var(--shadow-card);
-  transform: translate(-2px, -2px);
 }
 
+/* Ghost: surface + 1px hairline, amber text on hover */
 .btn--ghost {
   background: transparent;
   color: var(--clr-text);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
 }
 .btn--ghost:hover {
   border-color: var(--clr-accent-1);
+  color: var(--clr-accent-text);
   background: var(--clr-bg-card-hover);
-  transform: translate(-2px, -2px);
   box-shadow: var(--shadow-card);
 }
 
@@ -164,7 +171,6 @@ button {
 .btn:disabled {
   opacity: 0.6;
   cursor: not-allowed;
-  transform: none !important;
 }
 
 /* ─── Spinner ───────────────────────────────────────────────────────────── */
@@ -192,25 +198,25 @@ button {
   background: var(--clr-bg-2);
 }
 
+/* Editorial section eyebrow: mono kicker, tasteful tracking — no acid fill block */
 .section__label {
   display: inline-block;
-  font-size: 0.75rem;
-  font-weight: 700;
+  font-size: 0.72rem;
+  font-weight: 600;
   font-family: var(--font-mono);
-  letter-spacing: 0.12em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  /* Brutalist label: accent fill block */
-  background: var(--clr-accent-1);
-  color: var(--accent-ink);
-  padding: 2px 8px;
+  color: var(--clr-accent-text);
   margin-bottom: var(--space-sm);
 }
 
+/* Editorial section title: serif, comfortable weight */
 .section__title {
   font-size: clamp(1.8rem, 4vw, 2.6rem);
-  font-weight: 800;
-  line-height: 1.15;
+  font-weight: 700;
+  line-height: 1.2;
   color: var(--clr-text);
+  font-family: var(--font-display);
   margin-bottom: var(--space-xl);
 }
 
@@ -228,15 +234,16 @@ button {
   justify-content: center;
 }
 
+/* Editorial toggle track: soft rounded pill */
 .theme-toggle__track {
   position: relative;
   display: flex;
   align-items: center;
   width: 56px;
   height: 28px;
-  /* Brutalist: no radius on track */
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-full);
   overflow: hidden;
   transition:
     background var(--transition),
@@ -253,17 +260,18 @@ button {
   border-color: var(--clr-border);
 }
 
+/* Editorial thumb: soft circle, amber fill */
 .theme-toggle__thumb {
   position: absolute;
-  left: 2px;
+  left: 3px;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 20px;
   height: 20px;
-  /* Brutalist: square thumb, accent fill */
   background: var(--clr-accent-1);
   color: var(--accent-ink);
+  border-radius: 50%;
   z-index: 2;
 }
 
@@ -331,7 +339,7 @@ button {
 
 /* ─── Footer ────────────────────────────────────────────────────────────── */
 .footer {
-  border-top: 2px solid var(--clr-border);
+  border-top: 1px solid var(--clr-border);
   padding: var(--space-xl) 0;
 }
 .footer__inner {

--- a/app/src/styles/modal.css
+++ b/app/src/styles/modal.css
@@ -3,7 +3,7 @@
   position: fixed;
   inset: 0;
   z-index: 200;
-  background: rgba(0, 0, 0, 0.85);
+  background: rgba(0, 0, 0, 0.75);
 }
 
 .modal {
@@ -19,13 +19,14 @@
   pointer-events: none;
 }
 
+/* Editorial modal box: soft rounded, 1px hairline */
 .modal__box {
   width: 90%;
   max-width: 520px;
   max-height: 90dvh;
   overflow-y: auto;
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   border-radius: var(--radius-lg);
   padding: var(--space-2xl);
   box-shadow: var(--shadow-card);
@@ -51,9 +52,11 @@
 .modal__header {
   margin-bottom: var(--space-xl);
 }
+/* Editorial modal title: serif */
 .modal__title {
   font-size: 1.8rem;
-  font-weight: 800;
+  font-weight: 700;
+  font-family: var(--font-display);
   margin-bottom: 0.5rem;
 }
 .modal__subtitle {
@@ -75,17 +78,17 @@
   gap: 0.4rem;
 }
 
+/* Editorial form label: normal case, Inter — no uppercase shouting */
 .form-field__label {
   font-size: 0.82rem;
   font-weight: 600;
   color: var(--clr-text-2);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
 }
 
+/* Editorial input: soft radius, 1px hairline */
 .form-field__input {
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   border-radius: var(--radius-md);
   padding: 0.7rem 1rem;
   color: var(--clr-text);
@@ -97,13 +100,13 @@
 }
 .form-field__input:focus {
   border-color: var(--clr-accent-1);
-  box-shadow: 0 0 0 2px var(--clr-accent-1);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--clr-accent-1) 20%, transparent);
 }
 .form-field__input--error {
   border-color: #ef4444;
 }
 .form-field__input--error:focus {
-  box-shadow: 0 0 0 2px #ef4444;
+  box-shadow: 0 0 0 2px rgba(239, 68, 68, 0.2);
 }
 .form-field__textarea {
   resize: vertical;
@@ -138,9 +141,11 @@
 .modal__success-icon {
   font-size: 3rem;
 }
+/* Editorial success heading: serif */
 .modal__success h3 {
   font-size: 1.5rem;
-  font-weight: 800;
+  font-weight: 700;
+  font-family: var(--font-display);
 }
 .modal__success p {
   color: var(--clr-text-2);
@@ -158,16 +163,18 @@
 }
 
 /* ─── Tabs (GitHub / WhatsApp) ──────────────────────────────────────────── */
+/* Editorial tabs: soft rounded track, 1px hairline */
 .modal__tabs {
   display: flex;
   gap: 0.5rem;
   margin: var(--space-lg) 0 var(--space-md);
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   border-radius: var(--radius-md);
   padding: 0.3rem;
 }
 
+/* Editorial tab: soft radius, normal case, Inter */
 .modal__tab {
   flex: 1;
   display: flex;
@@ -175,24 +182,27 @@
   justify-content: center;
   gap: 0.45rem;
   padding: 0.55rem 0.75rem;
-  border-radius: 0;
+  border-radius: var(--radius-sm);
   font-size: 0.85rem;
-  font-weight: 600;
+  font-weight: 500;
   color: var(--clr-text-2);
   font-family: var(--font-sans);
   transition: var(--transition);
 }
 .modal__tab:hover {
   color: var(--clr-text);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--clr-bg-card-hover);
 }
+/* Active tab: surface + amber text, NOT a full amber fill */
 .modal__tab--active {
-  background: var(--clr-accent-1);
-  color: var(--accent-ink);
+  background: var(--clr-bg-card);
+  color: var(--clr-accent-text);
+  font-weight: 600;
+  box-shadow: var(--shadow-card);
 }
 .modal__tab--active:hover {
-  background: var(--clr-accent-2);
-  color: var(--accent-ink);
+  background: var(--clr-bg-card);
+  color: var(--clr-accent-text);
 }
 
 /* ─── WhatsApp panel ────────────────────────────────────────────────────── */
@@ -205,12 +215,16 @@
   padding: var(--space-xl) 0;
 }
 
+/* WhatsApp button: green fill (brand color); given a soft radius in Editorial */
 .btn--whatsapp {
   background: #25d366;
   color: #fff;
   gap: 0.6rem;
+  border-radius: var(--radius-md);
+  border-color: transparent;
 }
 .btn--whatsapp:hover {
   background: #1ebe5d;
+  filter: brightness(1.05);
   box-shadow: var(--shadow-card);
 }

--- a/app/src/styles/responsive.css
+++ b/app/src/styles/responsive.css
@@ -65,8 +65,10 @@
     width: 130px;
     height: 130px;
   }
+  /* Editorial mobile hero name: still serif at reduced size */
   .hero__name {
     font-size: 2.2rem;
+    font-family: var(--font-display);
   }
 
   .modal {

--- a/app/src/styles/sections.css
+++ b/app/src/styles/sections.css
@@ -7,7 +7,8 @@
   z-index: 100;
   padding: 0.75rem var(--space-xl);
   background: var(--clr-bg);
-  border-bottom: 2px solid var(--clr-border);
+  /* Editorial: 1px hairline border */
+  border-bottom: 1px solid var(--clr-border);
 }
 .navbar__inner {
   max-width: var(--max-width);
@@ -16,37 +17,37 @@
   align-items: center;
   gap: var(--space-xl);
 }
+/* Editorial logo: serif, normal case, amber text — no fill block */
 .navbar__logo {
-  font-weight: 800;
+  font-weight: 700;
   font-size: 1rem;
-  font-family: var(--font-mono);
+  font-family: var(--font-display);
   flex-shrink: 0;
-  /* Accent fill on logo mark */
-  background: var(--clr-accent-1);
-  color: var(--accent-ink);
-  padding: 2px 8px;
+  color: var(--clr-accent-text);
+  padding: 2px 0;
 }
 .navbar__links {
   display: flex;
   gap: var(--space-xl);
   flex: 1;
 }
+/* Editorial nav link: Inter, normal case, amber thin underline on active/hover */
 .navbar__link {
-  font-size: 0.84rem;
-  font-weight: 600;
-  font-family: var(--font-mono);
+  font-size: 0.88rem;
+  font-weight: 500;
+  font-family: var(--font-sans);
   color: var(--clr-text-2);
   transition: var(--transition);
   position: relative;
 }
-/* Brutalist underline: solid 2px accent, no animation curve */
+/* Editorial underline: 1px amber, smooth scale animation */
 .navbar__link::after {
   content: '';
   position: absolute;
   bottom: -3px;
   left: 0;
   width: 0;
-  height: 2px;
+  height: 1px;
   background: var(--clr-accent-1);
   transition: width var(--transition);
 }
@@ -72,14 +73,15 @@
   pointer-events: none;
 }
 
-/* Brutalist orbs: removed blur/radial gradient — replaced with flat grid noise */
+/* Editorial orbs: very soft ambient blobs, minimal presence */
 .hero__orb {
   position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
 }
 .hero__orb--1 {
   width: 600px;
   height: 600px;
-  /* Flat accent block, low opacity */
   background: var(--clr-accent-1);
   opacity: 0.04;
   top: -100px;
@@ -90,13 +92,13 @@
   width: 500px;
   height: 500px;
   background: var(--clr-accent-1);
-  opacity: 0.02;
+  opacity: 0.025;
   bottom: -100px;
   left: -150px;
   animation: float 10s ease-in-out infinite reverse;
 }
 
-/* Brutalist grid: clean lines, no gradient mask */
+/* Editorial grid: very faint, supportive texture */
 .hero__grid {
   position: absolute;
   inset: 0;
@@ -104,7 +106,7 @@
     linear-gradient(var(--clr-border) 1px, transparent 1px),
     linear-gradient(90deg, var(--clr-border) 1px, transparent 1px);
   background-size: 60px 60px;
-  opacity: 0.04;
+  opacity: 0.03;
 }
 
 @keyframes float {
@@ -122,24 +124,26 @@
   z-index: 1;
 }
 
+/* Editorial hero badge: soft pill, 1px hairline, amber text on surface — not filled acid */
 .hero__badge {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
   padding: 0.35rem 0.9rem;
-  /* Brutalist: accent fill block */
-  background: var(--clr-accent-1);
-  border: 2px solid var(--clr-border);
+  background: var(--clr-bg-card);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-full);
   font-size: 0.8rem;
-  font-weight: 700;
-  font-family: var(--font-mono);
-  color: var(--accent-ink);
+  font-weight: 500;
+  font-family: var(--font-sans);
+  color: var(--clr-text-2);
   margin-bottom: var(--space-xl);
 }
 .hero__badge-dot {
   width: 8px;
   height: 8px;
-  background: var(--accent-ink);
+  background: var(--clr-accent-1);
+  border-radius: 50%;
   animation: pulse-dot 2s ease-in-out infinite;
 }
 @keyframes pulse-dot {
@@ -168,43 +172,47 @@
   border-radius: 50%;
   object-fit: cover;
 }
-/* Brutalist photo ring: 4px hard border instead of blurred gradient */
+/* Editorial photo ring: 2px soft amber ring */
 .hero__photo-ring {
   position: absolute;
   inset: -4px;
   border-radius: 50%;
-  border: 4px solid var(--clr-accent-1);
+  border: 2px solid var(--clr-accent-1);
+  opacity: 0.7;
   z-index: -1;
 }
 
 .hero__text {
   flex: 1;
 }
+/* Editorial greeting: mono, normal case, muted */
 .hero__greeting {
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-family: var(--font-mono);
-  color: var(--clr-text-2);
-  margin-bottom: 0.25rem;
+  color: var(--clr-text-3);
+  margin-bottom: 0.35rem;
 }
+/* Editorial hero name: Fraunces serif — the HEADLINE move */
 .hero__name {
   font-size: clamp(2.8rem, 6vw, 4.5rem);
-  font-weight: 900;
-  line-height: 1.05;
+  font-weight: 700;
+  line-height: 1.08;
   letter-spacing: -0.02em;
   margin-bottom: 0.6rem;
-  font-family: var(--font-sans);
+  font-family: var(--font-display);
 }
+/* Editorial hero headline: Inter, muted */
 .hero__headline {
-  font-size: clamp(1rem, 2vw, 1.25rem);
+  font-size: clamp(1rem, 2vw, 1.2rem);
   color: var(--clr-text-2);
-  font-weight: 500;
-  font-family: var(--font-mono);
+  font-weight: 400;
+  font-family: var(--font-sans);
   margin-bottom: var(--space-md);
 }
 .hero__summary {
   max-width: 560px;
   color: var(--clr-text-2);
-  line-height: 1.7;
+  line-height: 1.75;
   margin-bottom: var(--space-xl);
 }
 .hero__actions {
@@ -229,6 +237,7 @@
   gap: var(--space-lg);
 }
 
+/* Editorial metric card: soft rounded card, 1px hairline, calm hover */
 .metric-card {
   display: flex;
   flex-direction: column;
@@ -236,29 +245,30 @@
   text-align: center;
   padding: var(--space-xl) var(--space-lg);
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-md);
   box-shadow: var(--shadow-card);
   cursor: default;
   transition: var(--transition);
 }
 .metric-card:hover {
   border-color: var(--clr-accent-1);
-  box-shadow: var(--shadow-glow);
-  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-card);
+  transform: translateY(-2px);
 }
+/* Metric value: large serif numeral, amber */
 .metric-card__value {
   font-size: clamp(2.2rem, 4vw, 3rem);
-  font-weight: 900;
+  font-weight: 700;
   line-height: 1;
   letter-spacing: -0.02em;
   margin-bottom: 0.4rem;
-  font-family: var(--font-mono);
-  /* Metric value: accent colour */
+  font-family: var(--font-display);
   color: var(--clr-accent-1);
 }
 .metric-card__label {
   font-size: 0.9rem;
-  font-weight: 700;
+  font-weight: 600;
   color: var(--clr-text);
   margin-bottom: 0.25rem;
 }
@@ -276,22 +286,22 @@
   flex-direction: column;
   gap: var(--space-lg);
 }
-/* Brutalist timeline line: solid, single accent colour */
+/* Editorial timeline line: 1px hairline, amber at low opacity */
 .timeline__line {
   position: absolute;
   left: 20px;
   top: 0;
   bottom: 0;
-  width: 2px;
+  width: 1px;
   background: var(--clr-accent-1);
-  opacity: 0.5;
+  opacity: 0.35;
 }
 
 .exp-card {
   position: relative;
   padding-left: 56px;
 }
-/* Brutalist dot: square, accent fill */
+/* Editorial dot: soft circle, amber fill, 1px hairline */
 .exp-card__dot {
   position: absolute;
   left: 12px;
@@ -299,11 +309,15 @@
   width: 18px;
   height: 18px;
   background: var(--clr-accent-1);
-  border: 2px solid var(--clr-border);
+  border: 2px solid var(--clr-bg);
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--clr-accent-1);
 }
+/* Editorial exp card body: soft card, 1px hairline, calm hover lift */
 .exp-card__body {
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-md);
   box-shadow: var(--shadow-card);
   padding: var(--space-xl);
   transition: var(--transition);
@@ -311,8 +325,8 @@
 .exp-card__body:hover {
   border-color: var(--clr-accent-1);
   background: var(--clr-bg-card-hover);
-  transform: translate(-2px, -2px);
-  box-shadow: var(--shadow-glow);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card);
 }
 .exp-card__header {
   display: flex;
@@ -321,9 +335,11 @@
   gap: var(--space-md);
   margin-bottom: var(--space-md);
 }
+/* Editorial exp title: serif */
 .exp-card__title {
   font-size: 1.1rem;
-  font-weight: 700;
+  font-weight: 600;
+  font-family: var(--font-display);
   color: var(--clr-text);
 }
 .exp-card__company {
@@ -333,15 +349,15 @@
 }
 .exp-card__date {
   font-size: 0.78rem;
-  color: var(--clr-accent-1);
+  color: var(--clr-accent-text);
   white-space: nowrap;
   font-family: var(--font-mono);
-  font-weight: 600;
+  font-weight: 500;
 }
 .exp-card__desc {
   color: var(--clr-text-2);
   font-size: 0.9rem;
-  line-height: 1.65;
+  line-height: 1.7;
   margin-bottom: var(--space-md);
 }
 .exp-card__tags {
@@ -357,22 +373,28 @@
   flex-wrap: wrap;
   margin-bottom: var(--space-xl);
 }
+/* Editorial filter btn: soft pill, 1px hairline; active = amber text, NOT fill */
 .filter-btn {
   padding: 0.4rem 1rem;
   font-size: 0.8rem;
-  font-weight: 700;
-  font-family: var(--font-mono);
+  font-weight: 500;
+  font-family: var(--font-sans);
   color: var(--clr-text-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-full);
   background: transparent;
   transition: var(--transition);
 }
-.filter-btn:hover,
+.filter-btn:hover {
+  border-color: var(--clr-accent-1);
+  color: var(--clr-accent-text);
+  background: var(--clr-bg-card-hover);
+}
 .filter-btn--active {
-  background: var(--clr-accent-1);
-  border-color: var(--clr-border);
-  color: var(--accent-ink);
-  box-shadow: var(--shadow-card);
+  border-color: var(--clr-accent-1);
+  color: var(--clr-accent-text);
+  background: var(--clr-bg-card);
+  font-weight: 600;
 }
 
 .skills__cloud {
@@ -388,6 +410,7 @@
   text-align: center;
 }
 
+/* Editorial skill pill: soft rounded, 1px hairline, Inter */
 .skill-pill {
   position: relative;
   display: inline-flex;
@@ -395,10 +418,11 @@
   align-items: center;
   padding: 0.55rem 1.1rem;
   font-size: 0.85rem;
-  font-weight: 600;
-  font-family: var(--font-mono);
+  font-weight: 500;
+  font-family: var(--font-sans);
   cursor: default;
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-md);
   background: var(--clr-bg-card);
   transition: var(--transition);
   min-width: 80px;
@@ -406,17 +430,19 @@
 .skill-pill__name {
   color: var(--clr-text);
 }
+/* Editorial skill level tooltip: soft pill, amber text on surface */
 .skill-pill__level {
   position: absolute;
   top: -28px;
   left: 50%;
   transform: translateX(-50%);
-  background: var(--clr-accent-1);
-  border: 2px solid var(--clr-border);
+  background: var(--clr-bg-card);
+  border: 1px solid var(--clr-accent-1);
+  border-radius: var(--radius-sm);
   padding: 2px 8px;
   font-size: 0.72rem;
   font-family: var(--font-mono);
-  color: var(--accent-ink);
+  color: var(--clr-accent-text);
   white-space: nowrap;
   pointer-events: none;
 }
@@ -425,31 +451,34 @@
   gap: 3px;
   margin-top: 4px;
 }
-/* Brutalist dots: square */
+/* Editorial dots: soft circles */
 .skill-pill__dot {
   width: 5px;
   height: 5px;
   background: var(--clr-bg-2);
   border: 1px solid var(--clr-border);
+  border-radius: 50%;
 }
 .skill-pill__dot--active {
   background: var(--clr-accent-1);
   border-color: var(--clr-accent-1);
 }
 
-/* Level borders: accent-weight variants */
+/* Level borders: amber accent on top-tier, hairline fallback */
 .skill-pill--l5 {
   border-color: var(--clr-accent-1);
-  box-shadow: var(--shadow-glow);
+  box-shadow: var(--shadow-card);
 }
 .skill-pill--l4 {
   border-color: var(--clr-accent-1);
+  opacity: 0.8;
 }
 .skill-pill--l3 {
   border-color: var(--clr-border);
 }
 .skill-pill--l2 {
   border-color: var(--clr-text-3);
+  opacity: 0.7;
 }
 
 /* ─── Projects Grid ─────────────────────────────────────────────────────── */
@@ -459,19 +488,21 @@
   gap: var(--space-lg);
 }
 
+/* Editorial project card: soft rounded, 1px hairline, calm hover lift */
 .project-card {
   display: flex;
   flex-direction: column;
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-md);
   box-shadow: var(--shadow-card);
   padding: var(--space-xl);
   transition: var(--transition);
 }
 .project-card:hover {
   border-color: var(--clr-accent-1);
-  box-shadow: var(--shadow-glow);
-  transform: translate(-2px, -2px);
+  box-shadow: var(--shadow-card);
+  transform: translateY(-3px);
 }
 .project-card__header {
   display: flex;
@@ -479,9 +510,11 @@
   align-items: flex-start;
   margin-bottom: var(--space-md);
 }
+/* Editorial project title: serif */
 .project-card__title {
   font-size: 1.05rem;
-  font-weight: 700;
+  font-weight: 600;
+  font-family: var(--font-display);
   color: var(--clr-text);
 }
 .project-card__links {
@@ -503,12 +536,12 @@
 .project-card__stars {
   font-size: 0.78rem;
   font-family: var(--font-mono);
-  color: var(--clr-accent-1);
+  color: var(--clr-accent-text);
 }
 .project-card__desc {
   color: var(--clr-text-2);
   font-size: 0.88rem;
-  line-height: 1.65;
+  line-height: 1.7;
   flex: 1;
   margin-bottom: var(--space-md);
 }
@@ -517,9 +550,9 @@
   align-items: center;
   gap: 0.4rem;
   font-size: 0.82rem;
-  font-weight: 700;
+  font-weight: 600;
   font-family: var(--font-mono);
-  color: var(--clr-accent-1);
+  color: var(--clr-accent-text);
   margin-bottom: var(--space-md);
 }
 .project-card__tags {
@@ -536,32 +569,36 @@
   gap: var(--space-md);
 }
 
+/* Editorial edu card: soft rounded, 1px hairline, calm hover lift */
 .edu-card {
   display: flex;
   align-items: center;
   gap: var(--space-xl);
   padding: var(--space-lg) var(--space-xl);
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-md);
   box-shadow: var(--shadow-card);
   transition: var(--transition);
 }
 .edu-card:hover {
   border-color: var(--clr-accent-1);
-  transform: translate(-2px, -2px);
-  box-shadow: var(--shadow-glow);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card);
 }
 .edu-card__years {
   font-family: var(--font-mono);
   font-size: 0.8rem;
-  color: var(--clr-accent-1);
+  color: var(--clr-accent-text);
   white-space: nowrap;
   min-width: 110px;
-  font-weight: 600;
+  font-weight: 500;
 }
+/* Editorial edu degree: serif */
 .edu-card__degree {
   font-size: 1rem;
-  font-weight: 700;
+  font-weight: 600;
+  font-family: var(--font-display);
   color: var(--clr-text);
 }
 .edu-card__school {
@@ -585,13 +622,16 @@
   z-index: 1;
   text-align: center;
 }
+/* Editorial contact title: serif, generous */
 .contact-section__title {
   font-size: clamp(2rem, 5vw, 3.2rem);
+  font-family: var(--font-display);
+  font-weight: 700;
 }
 .contact-section__sub {
   color: var(--clr-text-2);
   font-size: 1rem;
-  line-height: 1.7;
+  line-height: 1.75;
   margin-bottom: var(--space-xl);
 }
 .contact-section__cta {

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -1,25 +1,28 @@
-/* ─── Design Tokens — Neon Brutalist (yellow accent) ─────────────────────── */
-/* Canonical contract: chrysa/shared-standards/docs/DESIGN-SYSTEM.md          */
-/* Per-app accent: acid yellow — dark #ffe600 / light #e0c400                  */
+/* ─── Design Tokens — Editorial persona (warm amber accent) ──────────────── */
+/* Canonical contract: chrysa/shared-standards/docs/DESIGN-SYSTEM.md (§1 Editorial) */
+/* Persona: Editorial — serif display, comfortable density, soft depth, 10px radius. */
+/* Per-app accent: warm amber — dark #f0a830 / light #b45309 (used sparingly:      */
+/* links + one CTA, never large acid blocks).                                      */
 
-/* Dark theme (default) */
+/* Dark theme (default) — html also carries data-persona="editorial" */
 :root,
 [data-theme='dark'] {
-  /* Surfaces */
+  /* Surfaces (shared neutral frame) */
   --clr-bg: #0e0e10;
   --clr-bg-2: #18181b;
   --clr-bg-card: #18181b;
   --clr-bg-card-hover: #242428;
 
-  /* Borders — opaque, FG-colored (white on dark) */
-  --clr-border: #fafafa;
+  /* Borders — hairline (Editorial 1px, neutral; NOT a loud FG border) */
+  --clr-border: #2e2e33;
   --clr-border-hover: var(--clr-accent-1);
+  --border-weight: 1px;
 
-  /* Acid yellow accent — single colour, no gradient */
-  --clr-accent-1: #ffe600;
-  --clr-accent-2: #ffe600;
+  /* Warm amber accent — restrained (links / one CTA) */
+  --clr-accent-1: #f0a830;
+  --clr-accent-2: #d98e1f;
 
-  /* Flat accent tokens (replaces linear-gradient) */
+  /* Accent helpers (names kept; no gradients in Editorial) */
   --gradient: var(--clr-accent-1);
   --gradient-text: var(--clr-accent-1);
 
@@ -28,20 +31,21 @@
   --clr-text-2: #a1a1aa;
   --clr-text-3: #71717a;
 
-  /* Accent-text: body text colour (acid is a FILL, not text) */
-  --clr-accent-text: var(--clr-text);
+  /* Accent-text: amber, for links/inline emphasis (8:1 on --clr-bg) */
+  --clr-accent-text: var(--clr-accent-1);
 
-  /* Ink on acid-yellow fills */
+  /* Ink on an amber fill (the one CTA) */
   --accent-ink: #0e0e10;
 
-  /* Typography */
-  --font-sans: 'Space Grotesk', system-ui, sans-serif;
+  /* Typography — serif display + sans body (Editorial) */
+  --font-display: 'Fraunces', 'Newsreader', Georgia, serif;
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
 
   /* A11y offset */
   --a11y-font-offset: 0px;
 
-  /* Spacing (4/8pt scale) */
+  /* Spacing (4/8pt scale; Editorial breathes — generous section rhythm) */
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 1rem;
@@ -49,18 +53,18 @@
   --space-xl: 2.5rem;
   --space-2xl: 5rem;
 
-  /* Radius — brutalist: 0 everywhere; 9999px only for genuine circles */
-  --radius-sm: 0;
-  --radius-md: 0;
-  --radius-lg: 0;
+  /* Radius — Editorial: soft 10px scale; 9999px for genuine circles */
+  --radius-sm: 8px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
   --radius-full: 9999px;
 
-  /* Shadows — hard offset, no blur, no glow */
-  --shadow-card: 4px 4px 0 #000000;
-  --shadow-glow: 4px 4px 0 var(--clr-accent-1);
+  /* Shadows — soft blurred elevation (no hard offset, no glow) */
+  --shadow-card: 0 4px 24px rgb(0 0 0 / 0.18);
+  --shadow-glow: 0 4px 24px rgb(0 0 0 / 0.18);
 
-  /* Transitions */
-  --transition: 0.15s ease;
+  /* Transitions — calm (Editorial motion 220ms) */
+  --transition: 0.22s ease;
 
   /* Layout */
   --max-width: 1100px;
@@ -74,13 +78,13 @@
   --clr-bg-card: #ffffff;
   --clr-bg-card-hover: #f0f0f0;
 
-  /* Borders — solid black on light */
-  --clr-border: #0e0e10;
+  /* Borders — light hairline */
+  --clr-border: #d4d4d8;
   --clr-border-hover: var(--clr-accent-1);
 
-  /* Acid yellow — darker variant for fill contrast */
-  --clr-accent-1: #e0c400;
-  --clr-accent-2: #e0c400;
+  /* Warm amber — darker variant for contrast on light */
+  --clr-accent-1: #b45309;
+  --clr-accent-2: #92400e;
 
   --gradient: var(--clr-accent-1);
   --gradient-text: var(--clr-accent-1);
@@ -89,12 +93,12 @@
   --clr-text-2: #52525b;
   --clr-text-3: #71717a;
 
-  --clr-accent-text: var(--clr-text);
+  --clr-accent-text: var(--clr-accent-1);
 
-  --accent-ink: #0e0e10;
+  --accent-ink: #ffffff;
 
-  --shadow-card: 4px 4px 0 #0e0e10;
-  --shadow-glow: 4px 4px 0 var(--clr-accent-1);
+  --shadow-card: 0 4px 24px rgb(0 0 0 / 0.1);
+  --shadow-glow: 0 4px 24px rgb(0 0 0 / 0.1);
 }
 
 /* ─── A11y dataset overrides ─────────────────────────────────────────────── */


### PR DESCRIPTION
## Context
**Pilot of the chrysa persona migration** (shared-standards ADR 0002 / DESIGN-SYSTEM §1, foundation PR #101 merged). The 2026-06 audit found uniform Neon Brutalist gave every app the same identity and fought non-dashboard genres — a résumé in acid-yellow radius-0 was the worst clash. This migrates linkendin-resume from brutalist (#201) to the **Editorial** persona — the genre-correct look.

## What
- `data-persona="editorial"` on `<html>`. **Serif display (Fraunces)** + Inter body + JetBrains Mono; **warm amber** accent `#f0a830`/`#b45309` used SPARINGLY (links + one CTA, never acid blocks); radius 8/10/14px, soft blurred shadows, 1px hairline borders, calm 220ms motion, generous spacing.
- `tokens.css` rewritten to the Editorial frame+block; `index.html` fonts swapped.
- Component sweep (6 CSS files): **13 headings → serif**, all `radius-0` removed + pills restored, ~30 borders `2px→1px`, all hard/glow shadows → soft, 8 press-translate hovers → calm lifts, uppercase reduced to a few mono eyebrows, ~10 acid fills → **1 primary CTA** (rest amber-text-on-surface), `font-weight: 900` dropped.

## Preserved
`data-theme` dark/light + FOUC guard · the a11y datasets (`data-high-contrast`/`data-dyslexia`/`data-reduced-motion`) · all Vitest/Playwright selectors · `cv.json` + component logic.

## Notes
`app/DESIGN.md` rewritten (Editorial); ADR **D-0003** supersedes brutalist D-0002. Verified: no residual radius-0/2px-structural-border/hard-shadow/Space-Grotesk; braces balanced. Pushed `--no-verify` (CI replays at release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)