### PR TITLE
design(app): formalize DESIGN.md + English-only comments (light pass)

### DIFF
--- a/app/DESIGN.md
+++ b/app/DESIGN.md
@@ -1,0 +1,60 @@
+# linkendin-resume — Design System
+
+> Visual identity and token reference for the CV / portfolio app.
+> Conforms to `shared-standards/docs/UX-UI-GUIDELINES.md` and the `ui-ux` skill.
+
+## Relationship to the chrysa design system
+
+This is a **light-pass** repo in the portfolio design campaign. It was already
+polished, so it **keeps its own gradient identity** rather than adopting the Neon
+Brutalist DNA — this document formalises the existing system and the change set
+was limited to English-only comment compliance + this doc.
+
+## Identity
+
+**Personal portfolio / CV.** A deep dark canvas (light theme available) with a
+single **violet → cyan gradient** as the signature accent — used for emphasis
+text (`.gradient-text`), primary buttons, and focus. Calm surfaces, one expressive
+gradient.
+
+## Tokens (`src/styles/tokens.css`)
+
+CSS custom properties, theme-switched via `[data-theme]`. Every role exists in
+both themes.
+
+- **Colors** — `--clr-bg` / `--clr-bg-2` / `--clr-bg-card(-hover)`, `--clr-border(-hover)`.
+- **Accent** — `--clr-accent-1` (violet `#7c3aed`) → `--clr-accent-2` (cyan `#06b6d4`),
+  composed into `--gradient` / `--gradient-text`. `--clr-accent-text` is the
+  higher-contrast accent for text (documented **6.6:1** dark / **10.5:1 AAA** light).
+- **Text** — `--clr-text` / `-2` / `-3`, with inline WCAG ratios (≥ 4.6:1).
+- **Type** — Inter (sans) + JetBrains Mono. Spacing/radii/shadow/transition scales.
+
+## Theming & accessibility (a first-class feature)
+
+Beyond light/dark, the app exposes **runtime accessibility modes** (see
+`components/ui/AccessibilityPanel.tsx`) via `data-*` attributes on the root:
+
+- `data-high-contrast='true'` — pure-black surfaces, white text, stronger borders.
+- `data-dyslexia='true'` — switches the sans family to OpenDyslexic.
+- `data-reduced-motion='true'` — kills animations/transitions (also honours the
+  `prefers-reduced-motion` media query).
+- `--a11y-font-offset` — user-adjustable base font size.
+
+Baseline a11y (`src/styles/globals.css`):
+
+- Visible focus everywhere: `:focus-visible` 2px accent outline + offset.
+- **Skip nav** link, revealed on focus.
+- Touch targets ≥ 44px (theme toggle, buttons).
+- Documented contrast ratios meeting WCAG 2.1 AA (AAA for accent text in light).
+
+## Components
+
+CV sections in `src/components/cv/` (`Hero`, `ExperienceTimeline`, `ProjectsGrid`,
+`SkillsCloud`, `ImpactMetrics`, `EducationSection`, `ContactSection`, `Navbar`),
+plus `ui/` (`ThemeToggle`, `AccessibilityPanel`) and a `ContactModal`. Buttons:
+`.btn--primary` (gradient) / `.btn--ghost`, with `--sm/--lg/--full` sizes.
+
+## i18n
+
+FR + EN catalogs under `src/i18n/` (the only intentionally non-English source —
+locale data, not comments).

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -57,14 +57,14 @@ button {
   font-family: inherit;
 }
 
-/* ─── Accessibilité — Focus visible ─────────────────────────────────────── */
+/* ─── Accessibility — Focus visible ─────────────────────────────────────── */
 :focus-visible {
   outline: 2px solid var(--clr-accent-1);
   outline-offset: 3px;
   border-radius: var(--radius-sm);
 }
 
-/* ─── Accessibilité — Skip Nav ──────────────────────────────────────────── */
+/* ─── Accessibility — Skip nav ──────────────────────────────────────────── */
 .skip-nav {
   position: fixed;
   top: -100%;
@@ -85,7 +85,7 @@ button {
   outline-offset: 2px;
 }
 
-/* ─── Utilitaires ───────────────────────────────────────────────────────── */
+/* ─── Utilities ─────────────────────────────────────────────────────────── */
 .container {
   width: 100%;
   max-width: var(--max-width);
@@ -112,7 +112,7 @@ button {
   white-space: nowrap;
 }
 
-/* ─── Boutons ───────────────────────────────────────────────────────────── */
+/* ─── Buttons ───────────────────────────────────────────────────────────── */
 .btn {
   display: inline-flex;
   align-items: center;

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -1,9 +1,9 @@
 /* ─── Design Tokens ─────────────────────────────────────────────────────── */
 
-/* Thème sombre (défaut) */
+/* Dark theme (default) */
 :root,
 [data-theme='dark'] {
-  /* Couleurs */
+  /* Colors */
   --clr-bg: #0a0a0f;
   --clr-bg-2: #111118;
   --clr-bg-card: #16161f;
@@ -17,7 +17,7 @@
   --gradient: linear-gradient(135deg, var(--clr-accent-1), var(--clr-accent-2));
   --gradient-text: linear-gradient(90deg, var(--clr-accent-1), var(--clr-accent-2));
 
-  /* Texte */
+  /* Text */
   --clr-text: #e8e8f0;
   --clr-text-2: #a0a0b8;
   --clr-text-3: #8080a0; /* 4.8:1 on dark bg — WCAG AA large text */
@@ -25,7 +25,7 @@
   /* Accent text (higher contrast than decorative accent) */
   --clr-accent-text: #a78bfa; /* 6.6:1 on dark bg — WCAG AA ✓ */
 
-  /* Typographie */
+  /* Typography */
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
 
@@ -58,7 +58,7 @@
   --section-py: 6rem;
 }
 
-/* Thème clair */
+/* Light theme */
 [data-theme='light'] {
   --clr-bg: #f8f8fc;
   --clr-bg-2: #f0f0f8;


### PR DESCRIPTION
## What

Design-campaign **light pass** for linkendin-resume — the final repo in the campaign (excluding the deferred discordium). The app was already polished (light/dark, runtime a11y modes, documented WCAG ratios), so it **keeps its violet→cyan gradient identity** rather than adopting the Neon Brutalist DNA. Documentation + standards compliance only.

## Changes

- **`app/DESIGN.md`** (new) — formalize the existing system: gradient accent (`--clr-accent-1` violet → `--clr-accent-2` cyan), theme tokens, the **runtime accessibility modes** (`data-high-contrast`, `data-dyslexia` → OpenDyslexic, `data-reduced-motion`, `--a11y-font-offset` via `AccessibilityPanel`), skip-nav, `:focus-visible`, 44px targets, and the documented contrast ratios (AA; **AAA** for accent text in light).
- **`tokens.css` / `globals.css`** — translate the remaining **French comments** to English (chrysa English-only rule). No rule or value changed.

No visual or functional change.

## Verification (Docker)

- ✅ **vite build green** · ✅ **linter clean** · ✅ **107/116 unit tests pass**.
- ⚠️ 9 failures in `useTheme` / `ThemeToggle` are a **pre-existing environment issue** (`window.localStorage` undefined in the test runner), in files this PR does not touch — same root cause seen in the sport-intelligence-hub light pass.

## Design system

Portfolio-wide design campaign (Notion epic `37759293…`). Second of two light-pass repos; with this, every GUI repo bar the deferred discordium has a design PR open. Reference apps: mirrador #116, gaming-os #147, ai-aggregator #170, studioverse #84, server #173, sport-intelligence-hub #112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)