### PR TITLE
design(frontend): migrate to Editorial persona (warm amber)

### DIFF
--- a/app/DESIGN.md
+++ b/app/DESIGN.md
@@ -1,46 +1,65 @@
 # Design — linkendin-resume (cv-online)
 
-This frontend follows the chrysa **Neon Brutalist** design system:
-[`shared-standards/docs/DESIGN-SYSTEM.md`](https://github.com/chrysa/shared-standards/blob/main/docs/DESIGN-SYSTEM.md).
+This frontend follows the chrysa design system, **Editorial persona**:
+[`shared-standards/docs/DESIGN-SYSTEM.md`](https://github.com/chrysa/shared-standards/blob/main/docs/DESIGN-SYSTEM.md)
+§1 (Editorial). See [ADR 0002](https://github.com/chrysa/shared-standards/blob/main/docs/adr/0002-design-personas.md)
+for why the previous uniform "Neon Brutalist" look was superseded — a résumé is a
+reading surface, not a dashboard, so it gets the Editorial persona.
 
 ## Aesthetic
 
-Loud structure, flat fills, one acid accent. Radius `0`, 2px FG-colored borders
-(white on dark / black on light), hard offset shadows (`4px 4px 0`), **no
-gradients, no glow**, mono-forward type.
+Editorial: serif display type, readable sans body in normal case, generous
+spacing, soft rounded corners, soft blurred depth, calm motion. The accent is used
+**sparingly** (links, key figures, one CTA, the eyebrow), never as large acid
+fill blocks.
 
 ## Per-app accent
 
-**Acid yellow** — `#ffe600` (dark) · `#e0c400` (light, darker variant for fill
-contrast). Used only as **fill blocks** with `--accent-ink` (`#0e0e10`) text,
-never as acid text on the background. Distinct from every other campaign hue
-(lime/cyan/violet/orange/magenta/azure).
+**Warm amber** — `#f0a830` (dark) · `#b4690e` (light, darker variant for legibility
+on warm paper). Legible as text on the background (~8:1 dark / ~5:1 light), so it
+is used as link/eyebrow/figure colour as well as on the single primary CTA (where
+`--accent-ink` text sits on the amber fill). Distinct from every other app hue.
 
 ## Type
 
-- Display / body: **Space Grotesk** (`--font-sans`)
-- Mono (labels, dates, tech tags, metrics): **JetBrains Mono** (`--font-mono`)
+- Display (name, section titles, modal titles): **Fraunces** serif (`--font-display`)
+- Body / nav / UI: **Inter** (`--font-sans`), normal case
+- Data only (dates, metrics, stars, counts, terminal): **JetBrains Mono** (`--font-mono`)
 
 Loaded via Google Fonts in `app/index.html`.
 
+## Persona axes (vs. the shared frame)
+
+| Axis     | Value                                                                        |
+| -------- | ---------------------------------------------------------------------------- |
+| Radius   | `8 / 12 / 18px` (`--radius-sm/md/lg`); `9999px` for circles                  |
+| Depth    | soft blurred shadow (`--shadow-card: 0 6px 28px`); no hard offset            |
+| Border   | `1px` hairline (`--clr-border`, warm neutral)                                |
+| Motion   | calm `0.22s` ease; hover = soft lift (`translateY(-3px)`), no diagonal press |
+| Surfaces | warm near-black (dark) / warm paper (light)                                  |
+
 ## Tokens
 
-The single source of truth is `app/src/styles/tokens.css`. Every other
-stylesheet (`globals`, `components`, `sections`, `modal`, `animations`,
-`responsive`) reads its CSS custom properties, so re-theming happens in one
-place.
+The single source of truth is `app/src/styles/tokens.css`. Every other stylesheet
+(`globals`, `components`, `sections`, `modal`, `animations`, `responsive`) reads
+its CSS custom properties, so re-theming happens in one place. The Editorial
+brand layer (serif headings, de-filled eyebrow/logo/badge, soft corners) is an
+appended block at the end of `globals.css`.
 
 ## Theme mechanism (preserved)
 
-- `data-theme="dark" | "light"` on `<html>`, set by the FOUC guard in
-  `index.html` from `localStorage['theme']` and `prefers-color-scheme`, managed
-  at runtime by `useTheme` / `ThemeProvider`.
-- **Accessibility datasets** are preserved and still drive token overrides:
-  `data-high-contrast`, `data-dyslexia`, `data-reduced-motion`.
+- `data-theme="dark" | "light"` on `<html>`, set by the FOUC guard in `index.html`
+  from `localStorage['theme']` and `prefers-color-scheme`, managed at runtime by
+  `useTheme` / `ThemeProvider`.
+- **Accessibility datasets** still drive token overrides: `data-high-contrast`,
+  `data-dyslexia`, `data-reduced-motion`.
 
 ## Constraints honoured
 
-- WCAG 2.1 AA in both themes; yellow accent fills carry `#0e0e10` ink.
+- WCAG 2.1 AA in both themes; amber CTA fills carry `--accent-ink`; amber-as-text
+  meets AA on both backgrounds.
+- Body text is sans in normal case; mono is reserved for data — no uppercase-mono
+  paragraphs.
 - All test selectors (`data-testid`, roles, aria-labels, ids/classes queried by
   Vitest + Playwright) are unchanged — this was a restyle only.
 - Content remains data-driven from `app/cv.json`; no component logic changed.

--- a/app/index.html
+++ b/app/index.html
@@ -28,8 +28,8 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <!-- Neon Brutalist type — Space Grotesk (display) + JetBrains Mono -->
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet" />
+    <!-- Editorial type — Fraunces (serif display) + Inter (body) + JetBrains Mono (data) -->
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
     <script>
       (function () {
         var t = localStorage.getItem('theme');

--- a/app/src/components/cv/Hero.tsx
+++ b/app/src/components/cv/Hero.tsx
@@ -115,7 +115,7 @@ export function Hero({ onContactClick }: HeroProps) {
               className="hero__photo"
               onError={(e) => {
                 (e.target as HTMLImageElement).src =
-                  `https://ui-avatars.com/api/?name=${profile.firstName}+${profile.lastName}&background=7c3aed&color=fff&size=200`;
+                  `https://ui-avatars.com/api/?name=${profile.firstName}+${profile.lastName}&background=f0a830&color=1a160f&size=200`;
               }}
             />
             <div className="hero__photo-ring" aria-hidden="true" />

--- a/app/src/components/cv/ProjectsGrid.tsx
+++ b/app/src/components/cv/ProjectsGrid.tsx
@@ -169,7 +169,7 @@ export function ProjectsGrid() {
   const { repos, loading } = useGitHubRepos({ owner: GITHUB_CONFIG.owner });
 
   // GitHub contribution graph URL (ghchart service — public SVG embed)
-  const graphUrl = `https://ghchart.rshah.org/7c3aed/${GITHUB_CONFIG.owner}`;
+  const graphUrl = `https://ghchart.rshah.org/f0a830/${GITHUB_CONFIG.owner}`;
 
   return (
     <section id="projects" data-testid="projects-grid" className="section" ref={ref}>

--- a/app/src/styles/animations.css
+++ b/app/src/styles/animations.css
@@ -39,8 +39,8 @@
   font-family: var(--font-sans);
   font-weight: 700;
   font-size: 0.9rem;
-  border: 2px solid var(--clr-border);
-  border-radius: 0;
+  border: 1px solid var(--clr-border);
+  border-radius: var(--radius-full);
   box-shadow: var(--shadow-card);
   cursor: pointer;
   transition: var(--transition);
@@ -56,7 +56,7 @@
   }
   .floating-cta {
     padding: 0.85rem;
-    border-radius: 0;
+    border-radius: var(--radius-full);
   }
 }
 
@@ -67,7 +67,7 @@
   left: 50%;
   transform: translateX(-50%);
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   border-radius: var(--radius-md);
   padding: 0.7rem 0.9rem;
   min-width: 160px;

--- a/app/src/styles/components.css
+++ b/app/src/styles/components.css
@@ -23,7 +23,7 @@
   height: 2.8rem;
   /* Brutalist: square, 2px border, hard shadow */
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   color: var(--clr-text-2);
   display: flex;
   align-items: center;
@@ -54,7 +54,7 @@
   z-index: 200;
   width: 280px;
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   box-shadow: var(--shadow-card);
   padding: 1.25rem;
   display: flex;
@@ -103,7 +103,7 @@
   height: 1.6rem;
   /* Brutalist: square, 2px border */
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   color: var(--clr-text);
   cursor: pointer;
   display: flex;
@@ -138,7 +138,7 @@
   height: 1.35rem;
   /* Brutalist: square track */
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   position: relative;
   transition: background var(--transition);
   flex-shrink: 0;
@@ -177,7 +177,7 @@
   width: 100%;
   padding: 0.45rem 0.75rem;
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   color: var(--clr-text-2);
   font-size: 0.82rem;
   cursor: pointer;
@@ -216,7 +216,7 @@
   height: min(400px, 85vh);
   background: #0d1117;
   /* Brutalist: 2px border, hard shadow */
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
@@ -230,7 +230,7 @@
   gap: 0.5rem;
   padding: 0.6rem 1rem;
   background: #161b22;
-  border-bottom: 2px solid var(--clr-border);
+  border-bottom: 1px solid var(--clr-border);
   user-select: none;
   flex-shrink: 0;
 }
@@ -290,7 +290,7 @@
   align-items: center;
   gap: 0.5rem;
   padding: 0.6rem 1rem;
-  border-top: 2px solid var(--clr-border);
+  border-top: 1px solid var(--clr-border);
   background: #0d1117;
   flex-shrink: 0;
 }
@@ -331,7 +331,7 @@
   width: min(600px, 96vw);
   max-height: 70vh;
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   box-shadow: var(--shadow-card);
   overflow: hidden;
   display: flex;
@@ -343,7 +343,7 @@
   align-items: center;
   gap: 0.75rem;
   padding: 0.9rem 1rem;
-  border-bottom: 2px solid var(--clr-border);
+  border-bottom: 1px solid var(--clr-border);
   flex-shrink: 0;
 }
 
@@ -371,7 +371,7 @@
   font-size: 0.7rem;
   color: var(--clr-text-3);
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   padding: 0.15rem 0.4rem;
   font-family: var(--font-mono);
   flex-shrink: 0;
@@ -447,7 +447,7 @@
   align-items: center;
   gap: 1.25rem;
   padding: 0.55rem 1rem;
-  border-top: 2px solid var(--clr-border);
+  border-top: 1px solid var(--clr-border);
   font-size: 0.72rem;
   color: var(--clr-text-3);
   flex-shrink: 0;
@@ -458,7 +458,7 @@ kbd {
   display: inline-block;
   padding: 0.1em 0.35em;
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   font-family: var(--font-mono);
   font-size: 0.72rem;
   line-height: 1.4;
@@ -470,7 +470,7 @@ kbd {
 .github-graph {
   margin: 2rem 0;
   overflow: hidden;
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   background: var(--clr-bg-card);
   padding: 1rem;
   text-align: center;
@@ -542,7 +542,7 @@ kbd {
   height: 3rem;
   /* Brutalist: square, accent fill, 2px border */
   background: var(--clr-accent-1);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   color: var(--accent-ink);
   font-size: 1.3rem;
   display: flex;
@@ -563,7 +563,7 @@ kbd {
   z-index: 200;
   width: min(340px, 96vw);
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   box-shadow: var(--shadow-card);
   display: flex;
   flex-direction: column;
@@ -574,7 +574,7 @@ kbd {
   display: flex;
   align-items: center;
   padding: 0.75rem 1rem;
-  border-bottom: 2px solid var(--clr-border);
+  border-bottom: 1px solid var(--clr-border);
   background: var(--clr-bg-2);
   flex-shrink: 0;
 }
@@ -625,7 +625,7 @@ kbd {
   line-height: 1.5;
   word-break: break-word;
   /* Brutalist: sharp corner */
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
 }
 
 .askme-msg--user {
@@ -679,14 +679,14 @@ kbd {
   align-items: center;
   gap: 0.5rem;
   padding: 0.6rem 0.75rem;
-  border-top: 2px solid var(--clr-border);
+  border-top: 1px solid var(--clr-border);
   flex-shrink: 0;
 }
 
 .askme-panel__input {
   flex: 1;
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   padding: 0.45rem 0.75rem;
   color: var(--clr-text);
   font-size: 0.85rem;
@@ -705,7 +705,7 @@ kbd {
   width: 2rem;
   height: 2rem;
   background: var(--clr-accent-1);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   color: var(--accent-ink);
   font-size: 0.9rem;
   display: flex;

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -78,7 +78,7 @@ button {
   text-decoration: none;
   transition: top 0.2s;
   /* Brutalist: no radius, 2px border */
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
 }
 .skip-nav:focus {
   top: var(--space-md);
@@ -104,7 +104,7 @@ button {
   padding: 2px 10px;
   background: var(--clr-accent-1);
   color: var(--accent-ink);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   font-size: 0.75rem;
   font-family: var(--font-mono);
   white-space: nowrap;
@@ -122,7 +122,7 @@ button {
   font-family: var(--font-sans);
   cursor: pointer;
   /* Brutalist: no radius, 2px border */
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
 }
 
 .btn--primary {
@@ -133,18 +133,18 @@ button {
 }
 .btn--primary:hover {
   box-shadow: var(--shadow-card);
-  transform: translate(-2px, -2px);
+  transform: translateY(-3px);
 }
 
 .btn--ghost {
   background: transparent;
   color: var(--clr-text);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
 }
 .btn--ghost:hover {
   border-color: var(--clr-accent-1);
   background: var(--clr-bg-card-hover);
-  transform: translate(-2px, -2px);
+  transform: translateY(-3px);
   box-shadow: var(--shadow-card);
 }
 
@@ -172,7 +172,7 @@ button {
   display: inline-block;
   width: 16px;
   height: 16px;
-  border: 2px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.3);
   border-top-color: #fff;
   border-radius: 50%;
   animation: spin 0.7s linear infinite;
@@ -236,7 +236,7 @@ button {
   height: 28px;
   /* Brutalist: no radius on track */
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   overflow: hidden;
   transition:
     background var(--transition),
@@ -331,7 +331,7 @@ button {
 
 /* ─── Footer ────────────────────────────────────────────────────────────── */
 .footer {
-  border-top: 2px solid var(--clr-border);
+  border-top: 1px solid var(--clr-border);
   padding: var(--space-xl) 0;
 }
 .footer__inner {

--- a/app/src/styles/modal.css
+++ b/app/src/styles/modal.css
@@ -25,7 +25,7 @@
   max-height: 90dvh;
   overflow-y: auto;
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   border-radius: var(--radius-lg);
   padding: var(--space-2xl);
   box-shadow: var(--shadow-card);
@@ -85,7 +85,7 @@
 
 .form-field__input {
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   border-radius: var(--radius-md);
   padding: 0.7rem 1rem;
   color: var(--clr-text);
@@ -163,7 +163,7 @@
   gap: 0.5rem;
   margin: var(--space-lg) 0 var(--space-md);
   background: var(--clr-bg-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   border-radius: var(--radius-md);
   padding: 0.3rem;
 }
@@ -175,7 +175,7 @@
   justify-content: center;
   gap: 0.45rem;
   padding: 0.55rem 0.75rem;
-  border-radius: 0;
+  border-radius: var(--radius-sm);
   font-size: 0.85rem;
   font-weight: 600;
   color: var(--clr-text-2);

--- a/app/src/styles/responsive.css
+++ b/app/src/styles/responsive.css
@@ -106,3 +106,100 @@
     break-inside: avoid;
   }
 }
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Editorial persona layer — chrysa DESIGN-SYSTEM §1 (Editorial).
+   Serif display, sparing amber, readable sans body, soft rounded corners.
+   Lives in the LAST-imported stylesheet so it wins the cascade over the base
+   rules in globals/sections (which also define some of these selectors).
+   ───────────────────────────────────────────────────────────────────────── */
+
+/* Serif display for headings + brand name (grotesk → Fraunces) */
+.hero__name,
+.section__title,
+.modal__title,
+.contact-section__title,
+.modal__success h3 {
+  font-family: var(--font-display);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.hero__name {
+  font-weight: 700;
+}
+
+/* Body / nav text off mono → readable sans (mono reserved for data) */
+.hero__greeting,
+.hero__headline,
+.navbar__link {
+  font-family: var(--font-sans);
+}
+.hero__headline {
+  font-weight: 400;
+}
+
+/* Eyebrow label: understated amber text, not an acid fill block */
+.section__label {
+  background: transparent;
+  color: var(--clr-accent-text);
+  border: none;
+  padding: 0;
+  font-family: var(--font-sans);
+}
+
+/* Skill / meta tag: soft chip, not an acid fill */
+.tag {
+  background: var(--clr-bg-2);
+  color: var(--clr-text-2);
+  border: 1px solid var(--clr-border);
+  font-family: var(--font-sans);
+}
+
+/* Logo mark: amber wordmark, no fill block */
+.navbar__logo {
+  background: transparent;
+  color: var(--clr-accent-text);
+  padding: 0;
+}
+
+/* Availability badge: subtle surface pill, amber dot */
+.hero__badge {
+  background: var(--clr-bg-card);
+  color: var(--clr-text);
+  border: 1px solid var(--clr-border);
+  font-family: var(--font-sans);
+}
+.hero__badge-dot {
+  background: var(--clr-accent-1);
+}
+
+/* Soft rounded corners on the formerly square components */
+.btn,
+.filter-btn,
+.skill-pill,
+.skill-pill__level {
+  border-radius: var(--radius-sm);
+}
+.metric-card,
+.exp-card__body,
+.project-card,
+.edu-card,
+.a11y-panel,
+.askme-panel,
+.askme-panel__input,
+.askme-msg,
+.palette,
+.terminal,
+.github-graph,
+.hero__badge,
+.navbar__logo,
+.tag,
+kbd,
+.palette__esc,
+.a11y-trigger,
+.askme-trigger {
+  border-radius: var(--radius-md);
+}
+.exp-card__dot {
+  border-radius: var(--radius-full);
+}

--- a/app/src/styles/sections.css
+++ b/app/src/styles/sections.css
@@ -7,7 +7,7 @@
   z-index: 100;
   padding: 0.75rem var(--space-xl);
   background: var(--clr-bg);
-  border-bottom: 2px solid var(--clr-border);
+  border-bottom: 1px solid var(--clr-border);
 }
 .navbar__inner {
   max-width: var(--max-width);
@@ -129,7 +129,7 @@
   padding: 0.35rem 0.9rem;
   /* Brutalist: accent fill block */
   background: var(--clr-accent-1);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   font-size: 0.8rem;
   font-weight: 700;
   font-family: var(--font-mono);
@@ -236,7 +236,7 @@
   text-align: center;
   padding: var(--space-xl) var(--space-lg);
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   box-shadow: var(--shadow-card);
   cursor: default;
   transition: var(--transition);
@@ -244,7 +244,7 @@
 .metric-card:hover {
   border-color: var(--clr-accent-1);
   box-shadow: var(--shadow-glow);
-  transform: translate(-2px, -2px);
+  transform: translateY(-3px);
 }
 .metric-card__value {
   font-size: clamp(2.2rem, 4vw, 3rem);
@@ -299,11 +299,11 @@
   width: 18px;
   height: 18px;
   background: var(--clr-accent-1);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
 }
 .exp-card__body {
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   box-shadow: var(--shadow-card);
   padding: var(--space-xl);
   transition: var(--transition);
@@ -311,7 +311,7 @@
 .exp-card__body:hover {
   border-color: var(--clr-accent-1);
   background: var(--clr-bg-card-hover);
-  transform: translate(-2px, -2px);
+  transform: translateY(-3px);
   box-shadow: var(--shadow-glow);
 }
 .exp-card__header {
@@ -363,7 +363,7 @@
   font-weight: 700;
   font-family: var(--font-mono);
   color: var(--clr-text-2);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   background: transparent;
   transition: var(--transition);
 }
@@ -398,7 +398,7 @@
   font-weight: 600;
   font-family: var(--font-mono);
   cursor: default;
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   background: var(--clr-bg-card);
   transition: var(--transition);
   min-width: 80px;
@@ -412,7 +412,7 @@
   left: 50%;
   transform: translateX(-50%);
   background: var(--clr-accent-1);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   padding: 2px 8px;
   font-size: 0.72rem;
   font-family: var(--font-mono);
@@ -463,7 +463,7 @@
   display: flex;
   flex-direction: column;
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   box-shadow: var(--shadow-card);
   padding: var(--space-xl);
   transition: var(--transition);
@@ -471,7 +471,7 @@
 .project-card:hover {
   border-color: var(--clr-accent-1);
   box-shadow: var(--shadow-glow);
-  transform: translate(-2px, -2px);
+  transform: translateY(-3px);
 }
 .project-card__header {
   display: flex;
@@ -542,13 +542,13 @@
   gap: var(--space-xl);
   padding: var(--space-lg) var(--space-xl);
   background: var(--clr-bg-card);
-  border: 2px solid var(--clr-border);
+  border: 1px solid var(--clr-border);
   box-shadow: var(--shadow-card);
   transition: var(--transition);
 }
 .edu-card:hover {
   border-color: var(--clr-accent-1);
-  transform: translate(-2px, -2px);
+  transform: translateY(-3px);
   box-shadow: var(--shadow-glow);
 }
 .edu-card__years {

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -1,47 +1,49 @@
-/* ─── Design Tokens — Neon Brutalist (yellow accent) ─────────────────────── */
-/* Canonical contract: chrysa/shared-standards/docs/DESIGN-SYSTEM.md          */
-/* Per-app accent: acid yellow — dark #ffe600 / light #e0c400                  */
+/* ─── Design Tokens — Editorial persona (warm amber) ─────────────────────── */
+/* Canonical contract: chrysa/shared-standards/docs/DESIGN-SYSTEM.md §1 §3      */
+/* Persona: Editorial — serif display, readable sans body, soft depth, rounded, */
+/* accent used sparingly. Per-app accent: warm amber — dark #f0a830 / light #b4690e */
 
 /* Dark theme (default) */
 :root,
 [data-theme='dark'] {
-  /* Surfaces */
-  --clr-bg: #0e0e10;
-  --clr-bg-2: #18181b;
-  --clr-bg-card: #18181b;
-  --clr-bg-card-hover: #242428;
+  /* Surfaces — warm near-black */
+  --clr-bg: #100f0d;
+  --clr-bg-2: #16140f;
+  --clr-bg-card: #1a1814;
+  --clr-bg-card-hover: #221f19;
 
-  /* Borders — opaque, FG-colored (white on dark) */
-  --clr-border: #fafafa;
+  /* Borders — hairline, warm neutral (subtle, not structural) */
+  --clr-border: #2e2b25;
   --clr-border-hover: var(--clr-accent-1);
 
-  /* Acid yellow accent — single colour, no gradient */
-  --clr-accent-1: #ffe600;
-  --clr-accent-2: #ffe600;
+  /* Warm amber accent — used sparingly (links, one CTA, key figures) */
+  --clr-accent-1: #f0a830;
+  --clr-accent-2: #f6c66b;
 
-  /* Flat accent tokens (replaces linear-gradient) */
+  /* Editorial accent tokens (solid; no gradient) */
   --gradient: var(--clr-accent-1);
   --gradient-text: var(--clr-accent-1);
 
-  /* Text */
-  --clr-text: #fafafa;
-  --clr-text-2: #a1a1aa;
-  --clr-text-3: #71717a;
+  /* Text — warm off-white ramp */
+  --clr-text: #f7f5f2;
+  --clr-text-2: #b6b0a6;
+  --clr-text-3: #8a8478;
 
-  /* Accent-text: body text colour (acid is a FILL, not text) */
-  --clr-accent-text: var(--clr-text);
+  /* Accent-text: amber is legible as text on this bg (~8:1) — links/eyebrows */
+  --clr-accent-text: #f0a830;
 
-  /* Ink on acid-yellow fills */
-  --accent-ink: #0e0e10;
+  /* Ink on amber fills (amber is light → dark ink) */
+  --accent-ink: #1a160f;
 
-  /* Typography */
-  --font-sans: 'Space Grotesk', system-ui, sans-serif;
+  /* Typography — serif display + readable sans body; mono for data only */
+  --font-display: 'Fraunces', Georgia, 'Times New Roman', serif;
+  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
   --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
 
   /* A11y offset */
   --a11y-font-offset: 0px;
 
-  /* Spacing (4/8pt scale) */
+  /* Spacing (4/8pt scale) — generous for editorial reading */
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 1rem;
@@ -49,52 +51,53 @@
   --space-xl: 2.5rem;
   --space-2xl: 5rem;
 
-  /* Radius — brutalist: 0 everywhere; 9999px only for genuine circles */
-  --radius-sm: 0;
-  --radius-md: 0;
-  --radius-lg: 0;
+  /* Radius — editorial: soft rounded; 9999px for genuine circles */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 18px;
   --radius-full: 9999px;
 
-  /* Shadows — hard offset, no blur, no glow */
-  --shadow-card: 4px 4px 0 #000000;
-  --shadow-glow: 4px 4px 0 var(--clr-accent-1);
+  /* Shadows — soft blurred depth, no hard offset */
+  --shadow-card: 0 6px 28px rgb(0 0 0 / 0.32);
+  --shadow-glow: 0 8px 30px rgb(240 168 48 / 0.16);
 
-  /* Transitions */
-  --transition: 0.15s ease;
+  /* Transitions — calm */
+  --transition: 0.22s cubic-bezier(0.4, 0, 0.2, 1);
 
   /* Layout */
   --max-width: 1100px;
   --section-py: 6rem;
 }
 
-/* Light theme */
+/* Light theme — warm paper */
 [data-theme='light'] {
-  --clr-bg: #fafafa;
-  --clr-bg-2: #f0f0f0;
-  --clr-bg-card: #ffffff;
-  --clr-bg-card-hover: #f0f0f0;
+  --clr-bg: #f7f4ee;
+  --clr-bg-2: #efeae1;
+  --clr-bg-card: #fffdf9;
+  --clr-bg-card-hover: #f3eee4;
 
-  /* Borders — solid black on light */
-  --clr-border: #0e0e10;
+  /* Borders — warm hairline */
+  --clr-border: #ddd6ca;
   --clr-border-hover: var(--clr-accent-1);
 
-  /* Acid yellow — darker variant for fill contrast */
-  --clr-accent-1: #e0c400;
-  --clr-accent-2: #e0c400;
+  /* Amber — darker variant for legibility on paper */
+  --clr-accent-1: #b4690e;
+  --clr-accent-2: #c8821f;
 
   --gradient: var(--clr-accent-1);
   --gradient-text: var(--clr-accent-1);
 
-  --clr-text: #0e0e10;
-  --clr-text-2: #52525b;
-  --clr-text-3: #71717a;
+  --clr-text: #1c1813;
+  --clr-text-2: #5c5447;
+  --clr-text-3: #8a8276;
 
-  --clr-accent-text: var(--clr-text);
+  --clr-accent-text: #a85d09;
 
-  --accent-ink: #0e0e10;
+  /* Ink on amber fills (light-theme amber is dark → light ink) */
+  --accent-ink: #fffdf9;
 
-  --shadow-card: 4px 4px 0 #0e0e10;
-  --shadow-glow: 4px 4px 0 var(--clr-accent-1);
+  --shadow-card: 0 6px 24px rgb(60 40 10 / 0.12);
+  --shadow-glow: 0 8px 26px rgb(180 105 14 / 0.18);
 }
 
 /* ─── A11y dataset overrides ─────────────────────────────────────────────── */
@@ -107,7 +110,7 @@
   --clr-text-2: #dddddd;
   --clr-text-3: #bbbbbb;
   --clr-border: #ffffff;
-  --clr-accent-text: #ffffff;
+  --clr-accent-text: #ffd479;
 }
 
 [data-dyslexia='true'] {


### PR DESCRIPTION
## Why

First **per-app migration** of the design-system pivot
([shared-standards ADR 0002](https://github.com/chrysa/shared-standards/blob/main/docs/adr/0002-design-personas.md),
[DESIGN-SYSTEM §1](https://github.com/chrysa/shared-standards/blob/main/docs/DESIGN-SYSTEM.md)).
A résumé is a **reading surface**, not a dashboard — the uniform "Neon Brutalist"
look (acid-yellow, radius-0, hard shadows, uppercase-mono) was the worst genre
clash in the portfolio audit. This moves it to the **Editorial** persona.

## What

- **`tokens.css` revalue** — Fraunces serif display + Inter body + JetBrains Mono
  (data only); radius `8/12/18`; soft blurred shadows (no hard offset); hairline
  borders; **warm amber** accent (`#f0a830` dark / `#b4690e` light); warm surfaces;
  calm `0.22s` motion.
- **Sweeps** — 53 `2px` structural borders → `1px` hairline; diagonal
  press-translate → soft lift; brutalist `radius:0` overrides → rounded (CTA pill,
  modal tabs).
- **Editorial brand layer** (in last-imported `responsive.css` so it wins the
  cascade): serif headings, de-filled eyebrow / logo / availability badge, soft
  corners, nav+body off mono onto sans.
- **Fix** two leftover pre-brutalist violet literals (`#7c3aed`) the brutalist pass
  missed (TSX, not CSS): Hero avatar fallback + GitHub chart → amber.
- `index.html` web fonts; `DESIGN.md` documents the persona.

## Guarantees

- **Restyle only** — no component logic, `cv.json`, theme mechanism
  (`data-theme` + FOUC), a11y datasets (high-contrast / dyslexia / reduced-motion),
  or test selectors changed.
- `make ci` green (typecheck + lint + test + build).
- Verified in browser, **both themes** — Fraunces serif "Anthony **Gréau**", warm
  paper / warm near-black, amber CTA + avatar, understated eyebrow. Visibly a
  premium editorial CV, nothing like the acid-yellow brutalist version.

WCAG: amber CTA fills carry `--accent-ink`; amber-as-text meets AA on both
backgrounds; focus outlines kept at 2px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)