### PR TITLE
feat: add deploy workflow + bake Vite GitHub config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+---
+name: Deploy
+
+on:
+    release:
+        types: [published]
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: Image tag to deploy (e.g. v1.2.0)
+                required: true
+
+permissions:
+    contents: read
+    packages: write
+
+jobs:
+    deploy:
+        uses: chrysa/github-actions/.github/workflows/deploy.yml@main
+        with:
+            image-base: ghcr.io/chrysa/resume
+            tag: ${{ inputs.tag }}
+            backend-context: .
+            backend-dockerfile: docker/Dockerfile
+            target: prod
+            backend-build-args: |
+                VITE_GITHUB_OWNER=chrysa
+                VITE_GITHUB_REPO=contact
+                VITE_DEMO_MODE=false
+            gitops: true
+            api-values-path: apps/dev/linkendin-resume/values.yaml
+        secrets:
+            release-token: ${{ secrets.RELEASE_TOKEN }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,15 @@ RUN npm ci || npm install
 
 ENV PATH=/app/node_modules/.bin:$PATH
 
+# Build-time Vite configuration (baked into the static bundle). Defaults target
+# the chrysa contact repo; override via --build-arg in CI.
+ARG VITE_GITHUB_OWNER=chrysa
+ARG VITE_GITHUB_REPO=contact
+ARG VITE_DEMO_MODE=false
+ENV VITE_GITHUB_OWNER=$VITE_GITHUB_OWNER \
+    VITE_GITHUB_REPO=$VITE_GITHUB_REPO \
+    VITE_DEMO_MODE=$VITE_DEMO_MODE
+
 # Copy the rest of the application (configs + sources)
 COPY app/ ./
 


### PR DESCRIPTION
Adds a thin deploy caller (ghcr.io/chrysa/resume + catalog gitops) and bakes `VITE_GITHUB_OWNER/REPO/DEMO_MODE` into the build stage (defaults chrysa/contact) so the contact section works in the static bundle. Pairs with chrysa/catalog#39. Requires repo secret `RELEASE_TOKEN`.