### PR TITLE
ci: pin chrysa/github-actions reusable workflows to @v1.2.0

### DIFF
--- a/.github/workflows/action-check.yml
+++ b/.github/workflows/action-check.yml
@@ -16,4 +16,4 @@ on:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/action-check.yml@main
+    uses: chrysa/github-actions/.github/workflows/action-check.yml@v1.2.0

--- a/.github/workflows/approved-label.yml
+++ b/.github/workflows/approved-label.yml
@@ -10,4 +10,4 @@ concurrency:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/approved-label.yml@main
+    uses: chrysa/github-actions/.github/workflows/approved-label.yml@v1.2.0

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -10,4 +10,4 @@ on:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/auto-assign.yml@main
+    uses: chrysa/github-actions/.github/workflows/auto-assign.yml@v1.2.0

--- a/.github/workflows/auto-update-pre-commit.yml
+++ b/.github/workflows/auto-update-pre-commit.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/auto-update-pre-commit.yml@main
+    uses: chrysa/github-actions/.github/workflows/auto-update-pre-commit.yml@v1.2.0

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,4 +10,4 @@ concurrency:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@main
+    uses: chrysa/github-actions/.github/workflows/dependabot-auto-merge.yml@v1.2.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
     deploy:
-        uses: chrysa/github-actions/.github/workflows/deploy.yml@main
+        uses: chrysa/github-actions/.github/workflows/deploy.yml@v1.2.0
         with:
             image-base: ghcr.io/chrysa/resume
             tag: ${{ inputs.tag }}

--- a/.github/workflows/detect-conflicts.yml
+++ b/.github/workflows/detect-conflicts.yml
@@ -14,4 +14,4 @@ concurrency:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/detect-conflicts.yml@main
+    uses: chrysa/github-actions/.github/workflows/detect-conflicts.yml@v1.2.0

--- a/.github/workflows/enforce-feature-branch.yml
+++ b/.github/workflows/enforce-feature-branch.yml
@@ -7,4 +7,4 @@ on:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/enforce-feature-branch.yml@main
+    uses: chrysa/github-actions/.github/workflows/enforce-feature-branch.yml@v1.2.0

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,4 +11,4 @@ on:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/labeler.yml@main
+    uses: chrysa/github-actions/.github/workflows/labeler.yml@v1.2.0

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -19,4 +19,4 @@ on:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/dependencies.yml@main
+    uses: chrysa/github-actions/.github/workflows/dependencies.yml@v1.2.0

--- a/.github/workflows/pull-request-size.yml
+++ b/.github/workflows/pull-request-size.yml
@@ -6,4 +6,4 @@ on:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/pull-request-size.yml@main
+    uses: chrysa/github-actions/.github/workflows/pull-request-size.yml@v1.2.0

--- a/.github/workflows/quality-gate-check.yml
+++ b/.github/workflows/quality-gate-check.yml
@@ -19,4 +19,4 @@ permissions:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/quality-gate-check.yml@main
+        uses: chrysa/github-actions/.github/workflows/quality-gate-check.yml@v1.2.0

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,4 +13,4 @@ permissions:
 
 jobs:
     call:
-        uses: chrysa/github-actions/.github/workflows/secret-scan.yml@main
+        uses: chrysa/github-actions/.github/workflows/secret-scan.yml@v1.2.0

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,4 +15,4 @@ on:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/sync-labels.yml@main
+    uses: chrysa/github-actions/.github/workflows/sync-labels.yml@v1.2.0

--- a/.github/workflows/update-pr-body.yml
+++ b/.github/workflows/update-pr-body.yml
@@ -9,4 +9,4 @@ on:
 
 jobs:
   call:
-    uses: chrysa/github-actions/.github/workflows/update-pr-body.yml@main
+    uses: chrysa/github-actions/.github/workflows/update-pr-body.yml@v1.2.0


### PR DESCRIPTION
Pins all `chrysa/github-actions/.github/workflows/*.yml` references from `@main` to release tag `@v1.2.0` (verified to expose every referenced workflow). Addresses the **Pin GitHub Actions** item of the Standards compliance backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)