### PR TITLE
chore: sync chrysa shared standards

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,98 +3,122 @@ default_language_version:
 fail_fast: false
 minimum_pre_commit_version: 4.1.0
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
-    hooks:
-      - id: check-added-large-files
-        args: ['--maxkb=500']
-      - id: check-json
-        exclude: '^(\.csslintrc|app/node_modules/|app/dist/|node_modules/|dist/)'
-      - id: check-merge-conflict
-      - id: check-yaml
-        args:
-          - --allow-multiple-documents
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-      - id: detect-private-key
-      - args:
-          - --branch
-          - main
-        id: no-commit-to-branch
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        additional_dependencies:
-          - prettier@^3.8.4
-          - prettier-plugin-organize-imports@^4.3.0
-        args:
-          - --print-width=120
-          - --tab-width=2
-          - --use-tabs=false
-          - --single-quote
-          - --trailing-comma=es5
-        exclude: '^(app/dist/|app/coverage/|app/node_modules/|dist/|coverage/|node_modules/)'
-        files: '^app/.*\.(css|js|ts|tsx|json|md)$'
-  - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.12
-    hooks:
-      - id: actionlint
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.1
-    hooks:
-      - id: gitleaks
-  - repo: https://github.com/chrysa/pre-commit-tools
-    rev: v0.1.1-94
-    hooks:
-      - id: makefile-check
-      - id: console-debug-detection
-        files: '\.(js|gs|ts|tsx|jsx)$'
-      - id: console-log-detection
-        files: '\.(js|gs|ts|tsx|jsx)$'
-      - id: console-table-detection
-        files: '\.(js|gs|ts|tsx|jsx)$'
-      - id: react-console-error-detection
-      - id: no-console-warn
-      - id: ts-unreachable-code
-        additional_dependencies:
-          - tree-sitter>=0.25.2
-          - tree-sitter-typescript>=0.23.2
-      - id: css-duplicate-property
-      - id: import-no-relative-parent
-      - id: react-direct-dom
-      - id: dockerfile-no-latest
-      - id: env-file-check
-      - id: yaml-sorter
-        exclude: ^(\.github/(workflows|ISSUE_TEMPLATE)/|GitVersion\.yml)
-      - id: regression-gate
-        stages: [pre-push]
-      - id: json-sorter
-      - id: env-example-sync
-      - id: adr-gate
-  # TODO: add detect-duplicated-copilot-instructions after chrysa/pre-commit-tools#163 is merged and released
-  # --- python (all Python repos) ---
-      - id: debugger-detection
-      - id: python-print-detection
-      - id: python-pprint-detection
-        exclude: 'tests?/'
-      - id: no-bare-except
-      - id: python-logger-detection
-      - id: python-unreachable-code
-      - id: no-hardcoded-localhost
-        exclude: 'tests?/|\.test\.|\.spec\.'
-
-  - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.4.0
-    hooks:
-      - id: conventional-pre-commit
-        stages: [commit-msg]
-        args: [feat, fix, docs, style, refactor, test, chore, perf, revert, ci]
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.49.0
-    hooks:
-      - args:
-          - --fix
-        id: markdownlint
-        stages:
-          - manual
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v6.0.0
+  hooks:
+  - id: check-added-large-files
+    args:
+    - --maxkb=500
+  - id: check-json
+    exclude: ^(\.csslintrc|app/node_modules/|app/dist/|node_modules/|dist/)
+  - id: check-merge-conflict
+  - id: check-yaml
+    args:
+    - --allow-multiple-documents
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+  - id: detect-private-key
+  - args:
+    - --branch
+    - main
+    id: no-commit-to-branch
+- repo: https://github.com/pre-commit/mirrors-prettier
+  rev: v4.0.0-alpha.8
+  hooks:
+  - id: prettier
+    additional_dependencies:
+    - prettier@^3.8.4
+    - prettier-plugin-organize-imports@^4.3.0
+    args:
+    - --print-width=120
+    - --tab-width=2
+    - --use-tabs=false
+    - --single-quote
+    - --trailing-comma=es5
+    exclude: ^(app/dist/|app/coverage/|app/node_modules/|dist/|coverage/|node_modules/)
+    files: ^app/.*\.(css|js|ts|tsx|json|md)$
+- repo: https://github.com/rhysd/actionlint
+  rev: v1.7.12
+  hooks:
+  - id: actionlint
+- repo: https://github.com/gitleaks/gitleaks
+  rev: v8.30.1
+  hooks:
+  - id: gitleaks
+- repo: https://github.com/chrysa/pre-commit-tools
+  rev: v0.1.1-94
+  hooks:
+  - id: makefile-check
+  - id: console-debug-detection
+    files: \.(js|gs|ts|tsx|jsx)$
+  - id: console-log-detection
+    files: \.(js|gs|ts|tsx|jsx)$
+  - id: console-table-detection
+    files: \.(js|gs|ts|tsx|jsx)$
+  - id: react-console-error-detection
+  - id: no-console-warn
+  - id: ts-unreachable-code
+    additional_dependencies:
+    - tree-sitter>=0.25.2
+    - tree-sitter-typescript>=0.23.2
+  - id: css-duplicate-property
+  - id: import-no-relative-parent
+  - id: react-direct-dom
+  - id: dockerfile-no-latest
+  - id: env-file-check
+  - id: yaml-sorter
+    exclude: ^(\.github/(workflows|ISSUE_TEMPLATE)/|GitVersion\.yml)
+  - id: regression-gate
+    stages:
+    - pre-push
+  - id: json-sorter
+  - id: env-example-sync
+  - id: adr-gate
+  - id: debugger-detection
+  - id: python-print-detection
+  - id: python-pprint-detection
+    exclude: tests?/
+  - id: no-bare-except
+  - id: python-logger-detection
+  - id: python-unreachable-code
+  - id: no-hardcoded-localhost
+    exclude: tests?/|\.test\.|\.spec\.
+- repo: https://github.com/compilerla/conventional-pre-commit
+  rev: v4.4.0
+  hooks:
+  - id: conventional-pre-commit
+    stages:
+    - commit-msg
+    args:
+    - feat
+    - fix
+    - docs
+    - style
+    - refactor
+    - test
+    - chore
+    - perf
+    - revert
+    - ci
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.49.0
+  hooks:
+  - args:
+    - --fix
+    id: markdownlint
+    stages:
+    - manual
+- repo: local
+  hooks:
+  - id: gitversion-canonical-drift
+    name: GitVersion.yml canonical drift
+    entry: scripts/check-canonical-drift.sh GitVersion.yml templates/GitVersion.yml
+    language: system
+    pass_filenames: false
+    files: ^(GitVersion\.yml|templates/GitVersion\.yml)$
+  - id: cliff-canonical-drift
+    name: cliff.toml canonical drift
+    entry: scripts/check-canonical-drift.sh cliff.toml templates/cliff.toml
+    language: system
+    pass_filenames: false
+    files: ^(cliff\.toml|templates/cliff\.toml)$


### PR DESCRIPTION
Automated distribution of chrysa shared standards.

**Source:** `chrysa/shared-standards@5292b616e3723f95d2764649fe7b31429497d7ed`
Managed files (transverse `CLAUDE.md` import, `.chrysa/STANDARDS.md`,
shared skills/agents/commands, CI workflows, lint/quality, pre-commit)
were refreshed by `scripts/distribute-standards.sh`.

Review the diff: repo-specific content is preserved; only managed,
delimited blocks and shared files are updated.

Refs: chrysa/shared-standards