### PR TITLE
chore: adopt canonical GitVersion.yml (ContinuousDeployment)

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,20 +1,26 @@
 branches:
-  feat:
-    regex: ^feat[/-]
+  chore:
+    increment: Patch
+    mode: ContinuousDeployment
+    regex: ^chore/
+    tag: alpha
+  feature:
     increment: Minor
-    label: feat
-    source-branches:
-      - main
+    mode: ContinuousDeployment
+    regex: ^feat/
+    tag: alpha
   fix:
     increment: Patch
-    label: fix
-    regex: ^fix[/-]
-    source-branches:
-      - main
-  release:
+    mode: ContinuousDeployment
+    regex: ^fix/
+    tag: beta
+  main:
     increment: Patch
-    label: rc
-    regex: ^release[/-]
-    source-branches:
-      - main
-workflow: GitHubFlow/v1
+    mode: ContinuousDelivery
+    regex: ^main$
+    tag: ''
+increment: Inherit
+major-version-bump-message: ^(feat|fix|refactor)(\(.+\))?!:.+
+minor-version-bump-message: ^feat(\(.+\))?:.+
+mode: ContinuousDeployment
+patch-version-bump-message: ^(fix|refactor|perf|docs|chore)(\(.+\))?:.+


### PR DESCRIPTION
Adopt canonical chrysa ContinuousDeployment GitVersion config (matches `shared-standards/GitVersion.yml`), replacing legacy/non-canonical settings. Part of the P0 release-config conformance fan-out. Refs chrysa/shared-standards#127