### PR TITLE
chore(pre-commit): bump pre-commit-tools to v0.1.1-95 (makefile-check fix)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
   hooks:
   - id: gitleaks
 - repo: https://github.com/chrysa/pre-commit-tools
-  rev: v0.1.1-94
+  rev: v0.1.1-95
   hooks:
   - id: makefile-check
   - id: console-debug-detection


### PR DESCRIPTION
makefile-check at v0.1.1-94 can't resolve `include $(shell find ... *.Makefile)`, so it falsely reports the tier's required targets missing (they exist in included makefiles). v0.1.1-95 has the include-resolution fix.

Generated with Claude Code