### PR TITLE
ci: SKIP no-commit-to-branch in pre-commit job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files --show-diff-on-failure
         shell: bash
+        env:
+          SKIP: no-commit-to-branch
 
   version:
     name: Compute version (GitVersion)


### PR DESCRIPTION
The Pre-commit checks job runs `pre-commit run --all-files` on a main checkout, so the `no-commit-to-branch` hook always fails (exit 1) on push to main — the only failing hook. Standard chrysa fix (as in the reusable ci-python.yml + shared-standards): set `env: SKIP: no-commit-to-branch` on the step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)