### PR TITLE
feat(design): brand-theme pilot — linkendin-resume (logbook concept)

### DIFF
--- a/app/BRAND-BRIEF.md
+++ b/app/BRAND-BRIEF.md
@@ -36,7 +36,7 @@ gridlines, and a quiet authority that comes from the work being documented, not 
 
 - **The Manual / technical reference manuals (LaTeX `book` class, O'Reilly animal books):**
   borrow the disciplined measure, the generous margin reserved for marginalia/metadata, the
-  sober display serif used with restraint, and the sense that the page is *typeset*, not laid out.
+  sober display serif used with restraint, and the sense that the page is _typeset_, not laid out.
 - **A well-kept terminal / `man` page:** borrow the monospaced data voice for dates, tech tags,
   and metadata, and one literal terminal-prompt marker (`▸ §`) that signals "an engineer made this".
 - **Engineering field notebook (quadrille/grid paper):** borrow the faint rule-and-tick grid and
@@ -47,21 +47,21 @@ gridlines, and a quiet authority that comes from the work being documented, not 
 A **monospaced index-rail running down the left edge of the page** — a slim vertical spine of
 section numbers, tick marks, and a terminal-prompt section marker that the reader's eye tracks as
 they scroll, like the spine/margin of a bound logbook. It is the one thing that makes this read as
-a *deliberate engineering document* and not a generic dark résumé template.
+a _deliberate engineering document_ and not a generic dark résumé template.
 
 ---
 
 ## Derived decisions
 
 - **Type:** display = **Spectral** (a sober, technical-feeling text serif with quiet authority —
-  keeps the "typeset monograph" gravitas of the old Fraunces but reads as a *reference-manual*
+  keeps the "typeset monograph" gravitas of the old Fraunces but reads as a _reference-manual_
   serif rather than a fashionable display face); body = **Inter** (kept — neutral, legible UI/body
   workhorse); data = **JetBrains Mono** (kept — the logbook/terminal voice for the index-rail,
   dates, tech tags, metric sub-labels, and entry numbers).
 - **Color:** accent = **signal cyan/teal `#3bd6c6` (dark) / `#0e7c70` (light)** — a precise
   instrument-readout hue (oscilloscope trace, terminal status, satellite-telemetry green-cyan)
   that reads as "measured signal" rather than the warm, editorial-magazine amber it replaces; it
-  fits *precise / quiet-authority* and ties to the space/mobility/infra story. surface mood =
+  fits _precise / quiet-authority_ and ties to the space/mobility/infra story. surface mood =
   **cool neutral** (near-black graphite `#0e0e10` dark / paper `#fafafa` light — the page of the
   logbook, never warm).
 - **Shape & depth:** radius = **tight `4px` (sm) / `6px` (md) / `8px` (lg)**, `9999px` only for
@@ -69,10 +69,10 @@ a *deliberate engineering document* and not a generic dark résumé template.
   pillowy. border = **crisp 1px hairlines in a structural border colour**, used as actual rules
   (the grid), with the index-rail drawn as a 1px tick column. shadow = **near-flat** — replace the
   soft 24px blur with a minimal `0 1px 0` hairline-edge + very faint elevation; depth comes from
-  rules and the grid, not glow, so the page feels *printed*.
+  rules and the grid, not glow, so the page feels _printed_.
 - **Motion personality:** **calm** — short (~160–200ms), linear/`ease-out`, no spring or bounce.
   signature transition = on scroll, each logbook entry's number + tick on the index-rail
-  *ticks/registers in* (a 1px-precise fade + 2px settle), like a plotter advancing one line. Fully
+  _ticks/registers in_ (a 1px-precise fade + 2px settle), like a plotter advancing one line. Fully
   **reduced-motion-safe**: under `data-reduced-motion`/`prefers-reduced-motion` the rail and entries
   render in their final state with no movement — the signature is structural (drawn in CSS), not
   animation-dependent.

--- a/app/BRAND-BRIEF.md
+++ b/app/BRAND-BRIEF.md
@@ -1,0 +1,92 @@
+# linkendin-resume — Brand Brief
+
+> Direction proposal — open to redirection by the owner before/after the pilot PR.
+
+> The repeatable discovery that derives this app's identity from its job, not a genre.
+> Fill all 6 prompts, then translate the answers into the design decisions at the bottom.
+
+## 1. Job-to-be-done
+
+A recruiter, CTO, or potential client lands here to decide, in under a minute, whether
+Anthony Gréau is the senior backend/systems engineer they want to talk to — and to leave
+with a way to reach him (contact / open an issue) without ever opening a PDF.
+
+## 2. Audience
+
+Technical decision-makers and their gatekeepers: engineering managers, CTOs, lead engineers,
+and technical recruiters at scale-ups, research labs, and consultancies. They are literate in
+software and infrastructure (they recognise "k3s", "GitOps", "1,000+ commits", "Solar Orbiter"
+as signal, not noise), time-poor, and skim before they read. Primarily desktop/laptop during
+sourcing, with a meaningful mobile minority reading a shared link on the move. FR + EN.
+
+## 3. Three mood words
+
+precise / crafted / quiet-authority
+
+(Calm and deliberate over loud and animated. Every element looks measured, like it was placed
+on a grid by someone who cares about correctness.)
+
+## 4. Metaphor
+
+An **engineering logbook / technical monograph** — the bound field notebook of a systems
+engineer: a precise running record with a measured margin, numbered entries, hand-ruled
+gridlines, and a quiet authority that comes from the work being documented, not decorated.
+
+## 5. References (2-3)
+
+- **The Manual / technical reference manuals (LaTeX `book` class, O'Reilly animal books):**
+  borrow the disciplined measure, the generous margin reserved for marginalia/metadata, the
+  sober display serif used with restraint, and the sense that the page is *typeset*, not laid out.
+- **A well-kept terminal / `man` page:** borrow the monospaced data voice for dates, tech tags,
+  and metadata, and one literal terminal-prompt marker (`▸ §`) that signals "an engineer made this".
+- **Engineering field notebook (quadrille/grid paper):** borrow the faint rule-and-tick grid and
+  the numbered-entry convention (experience entries read as logbook entries `[01] [02] …`).
+
+## 6. Remembered for
+
+A **monospaced index-rail running down the left edge of the page** — a slim vertical spine of
+section numbers, tick marks, and a terminal-prompt section marker that the reader's eye tracks as
+they scroll, like the spine/margin of a bound logbook. It is the one thing that makes this read as
+a *deliberate engineering document* and not a generic dark résumé template.
+
+---
+
+## Derived decisions
+
+- **Type:** display = **Spectral** (a sober, technical-feeling text serif with quiet authority —
+  keeps the "typeset monograph" gravitas of the old Fraunces but reads as a *reference-manual*
+  serif rather than a fashionable display face); body = **Inter** (kept — neutral, legible UI/body
+  workhorse); data = **JetBrains Mono** (kept — the logbook/terminal voice for the index-rail,
+  dates, tech tags, metric sub-labels, and entry numbers).
+- **Color:** accent = **signal cyan/teal `#3bd6c6` (dark) / `#0e7c70` (light)** — a precise
+  instrument-readout hue (oscilloscope trace, terminal status, satellite-telemetry green-cyan)
+  that reads as "measured signal" rather than the warm, editorial-magazine amber it replaces; it
+  fits *precise / quiet-authority* and ties to the space/mobility/infra story. surface mood =
+  **cool neutral** (near-black graphite `#0e0e10` dark / paper `#fafafa` light — the page of the
+  logbook, never warm).
+- **Shape & depth:** radius = **tight `4px` (sm) / `6px` (md) / `8px` (lg)**, `9999px` only for
+  true circles — squarer than Editorial's soft 10–14px, reading as drafted/ruled rather than
+  pillowy. border = **crisp 1px hairlines in a structural border colour**, used as actual rules
+  (the grid), with the index-rail drawn as a 1px tick column. shadow = **near-flat** — replace the
+  soft 24px blur with a minimal `0 1px 0` hairline-edge + very faint elevation; depth comes from
+  rules and the grid, not glow, so the page feels *printed*.
+- **Motion personality:** **calm** — short (~160–200ms), linear/`ease-out`, no spring or bounce.
+  signature transition = on scroll, each logbook entry's number + tick on the index-rail
+  *ticks/registers in* (a 1px-precise fade + 2px settle), like a plotter advancing one line. Fully
+  **reduced-motion-safe**: under `data-reduced-motion`/`prefers-reduced-motion` the rail and entries
+  render in their final state with no movement — the signature is structural (drawn in CSS), not
+  animation-dependent.
+- **Signature element:** the **monospaced index-rail / logbook spine** — a slim fixed-measure
+  vertical column running down the left of the content, carrying: zero-padded section/entry numbers
+  (`[01] [02] …`), fine tick marks aligned to the baseline grid, and a **terminal-prompt section
+  marker** (`▸ §` / `$`) at each section head. Token-driven (rail width, tick colour, prompt glyph
+  all from `tokens.css`), drawn with borders + pseudo-elements so it survives reduced-motion and
+  print. This is the memorable, non-generic device.
+- **IA:** primary view = **a single, generously-margined readable column** (the monograph page),
+  index-rail in the reserved left margin, content right of it. central object = **the candidate
+  (Anthony)** — the hero name + headline + one-line summary, presented as the title page / colophon
+  of the monograph. primary action = **Contact / open a GitHub issue** (the one accent-filled CTA;
+  CV download/print as a quiet secondary), reachable from the hero and persistently from the rail.
+  density = **comfortable-but-information-dense** — generous vertical rhythm and margin (it breathes
+  like a typeset book), but each entry is compact and metadata-rich (mono dates, tech tags, numbers)
+  so a skimming reader extracts signal fast.

--- a/app/DESIGN.md
+++ b/app/DESIGN.md
@@ -1,72 +1,99 @@
-# Design — linkendin-resume (cv-online)
+# linkendin-resume — Design (Brand Theme)
 
-This frontend follows the chrysa **Editorial** design persona:
-[`shared-standards/docs/DESIGN-SYSTEM.md §1 Editorial`](https://github.com/chrysa/shared-standards/blob/main/docs/DESIGN-SYSTEM.md)
-and accent-restraint rules from `§4 Accent`.
+> Conforms to the chrysa Brand-Themes Design System
+> (`shared-standards/docs/DESIGN-SYSTEM.md`). No persona — this app is its own brand.
 
-## Persona
+## Brand brief
 
-`data-persona="editorial"` is set on `<html>` in `app/index.html`.
+See `BRAND-BRIEF.md`. Summary: an **engineering logbook / technical monograph** —
+the bound field notebook of a systems engineer. Mood: precise / crafted /
+quiet-authority. Authority comes from the work being documented, not decorated:
+a measured margin, numbered entries, hairline rules, and a monospaced data voice.
 
-Editorial reads as an elegant, readable résumé piece. The differentiator is
-the Fraunces serif for all display headings combined with Inter for body text
-— that contrast signals "crafted document" rather than "generic web app".
-Spacing is generous, cards are softly rounded, and the warm amber accent is
-used sparingly: one primary CTA fill, amber text for links and section kickers,
-never large acid fill blocks.
+## Contract conformance
 
-## Accent
+- Imports `contract.css` (semantic token names + a11y floor): **yes** —
+  `@import './contract.css';` at the top of `app/src/styles/tokens.css`.
+- `@chrysa/ui` class/behavior contract honored (if used): **n/a** — this app ships
+  its own components and CSS; it has no `@chrysa/ui` dependency. The brand is
+  applied by defining the semantic contract tokens with brand values and aliasing
+  the app's local `--clr-*` token names to them, so existing components inherit the
+  brand with no markup churn.
+- WCAG AA verified both themes: **yes** — contrast ratios computed against the
+  WCAG 2.1 relative-luminance formula (see ratios below). All checked pairs ≥ 4.5:1.
 
-**Warm amber** — dark theme `#f0a830` / light theme `#b45309` (darker for
-contrast on white). Used only as:
+## Theme tokens
 
-- `background` on the **one primary CTA** button (`.btn--primary`) and the
-  Ask Me trigger / send button.
-- `color` on links, section eyebrows (`.section__label`), dates, metric values,
-  and the `--clr-accent-text` token.
-- Never as a large fill block filling headers, badges, nav logos, or filter tabs.
+Single source of truth: `app/src/styles/tokens.css`. It imports the semantic
+registry from `contract.css`, sets the brand values for both `:root`/dark and
+`[data-theme='light']`, then aliases every local `--clr-*` / component token to a
+semantic one. Every other stylesheet reads these custom properties unchanged.
 
-## Typography
+**Palette**
 
-- **Display / headings**: `Fraunces` (serif, optical sizes) — `--font-display`.
-  Applied to: hero name, section titles, card titles, exp/edu/modal titles,
-  metric values, contact section title, projects sub-titles.
-- **Body / UI**: `Inter` — `--font-sans`. Applied to body text, nav links,
-  buttons, labels, form fields.
-- **Mono / data**: `JetBrains Mono` — `--font-mono`. Applied to dates, section
-  eyebrow kickers, tech tags, metric sub-labels, terminal.
+| Token | Dark | Light |
+|---|---|---|
+| `--bg` | `#0e0e10` (graphite page) | `#fafafa` (paper) |
+| `--surface` | `#18181b` | `#ffffff` |
+| `--fg` | `#fafafa` | `#0e0e10` |
+| `--muted` | `#a1a1aa` | `#52525b` |
+| `--border` | `#2e2e33` | `#d4d4d8` |
+| `--accent` | `#3bd6c6` (signal teal) | `#0e7c70` (deep teal) |
+| `--accent-ink` | `#0e0e10` | `#ffffff` |
 
-Loaded via Google Fonts in `app/index.html`.
+**Shape & depth:** squarer/flatter — `--radius-sm 4px` / `--radius-md 6px` /
+`--radius-lg 8px`, `9999px` only for true circles; `--border-weight 1px` hairlines
+used as actual rules; near-flat `--shadow: 0 1px 0` edge instead of a soft blur.
 
-## Tokens
+**Type:** display **Spectral** (`--font-display`, replaces Fraunces — a sober
+reference-manual serif), body **Inter** (`--font-body`/`--font-sans`), data
+**JetBrains Mono** (`--font-mono`). Loaded via Google Fonts in `app/index.html`.
 
-The single source of truth is `app/src/styles/tokens.css`. Every other
-stylesheet (`globals`, `components`, `sections`, `modal`, `animations`,
-`responsive`) reads its CSS custom properties, so re-theming happens in one
-place.
+**Motion:** calm — `--motion: 180ms` linear/ease-out, no spring/bounce.
 
-Key Editorial token values:
+**AA contrast ratios (verified):**
 
-- `--radius-sm: 8px` / `--radius-md: 10px` / `--radius-lg: 14px` / `--radius-full: 9999px`
-- `--shadow-card: 0 4px 24px rgb(0 0 0 / 0.18)` (soft blurred, no hard offset)
-- `--border-weight: 1px` (hairline — never 2px FG-colored)
-- `--transition: 0.22s ease` (calm motion)
+| Pair | Dark | Light |
+|---|---|---|
+| `--fg` on `--bg` | 18.48:1 | 18.48:1 |
+| `--muted` on `--bg` | 7.52:1 | 7.41:1 |
+| `--accent-ink` on `--accent` fill | 10.67:1 | 5.08:1 |
+| `--accent` as text on `--bg` | 10.67:1 | 4.86:1 |
 
-## Theme mechanism (preserved)
+All ≥ 4.5:1 (normal text). The demo banner (`--accent-ink` on `--warning`) is
+11.55:1 dark / 5.02:1 light. The terminal easter-egg keeps authentic ANSI colours
+(amber 8.81:1, cyan 7.79:1 on its own `#0d1117` window) — legible and intentional.
 
-- `data-theme="dark" | "light"` on `<html>`, set by the FOUC guard in
-  `index.html` from `localStorage['theme']` and `prefers-color-scheme`, managed
-  at runtime by `useTheme` / `ThemeProvider`.
-- **Accessibility datasets** are preserved and still drive token overrides:
-  - `data-high-contrast` — increases contrast on borders and text
-  - `data-dyslexia` — switches `--font-sans` to OpenDyslexic
-  - `data-reduced-motion` — collapses all animation/transition durations to 0.01ms
+## Signature element
 
-## Constraints honoured
+The **monospaced index-rail / logbook spine** — a slim vertical column down the
+reserved left margin of each numbered section, carrying zero-padded entry numbers
+(`[01]`, `[02]`…), a 1px structural hairline spine, a terminal-prompt section
+marker (`▸ §`), and an accent registration tick aligned to each section head.
 
-- WCAG 2.1 AA in both themes; amber on dark `#f0a830` / `#0e0e10` meets 7:1.
-  Amber on light `#b45309` on `#fafafa` meets 4.8:1 (AA).
-- All test selectors (`data-testid`, roles, aria-labels, ids/classes queried by
-  Vitest + Playwright) are unchanged — this was a restyle only.
-- Content remains data-driven from `app/cv.json`; no component logic changed.
-- Skip-nav, i18n, and keyboard navigation are unaffected.
+It is drawn entirely in CSS (`app/src/styles/sections.css`): a `logbook` counter
+reset on `<main>` and incremented per `main > .section`, with the number + prompt
+glyph rendered via `.container::after` and the spine via `.container::before`. No
+JS, no markup change. It is token-driven (`--rail-width`, `--rail-tick`,
+`--rail-num`, `--rail-prompt`, `--rail-prompt-glyph`, `--font-mono`), reduced-motion
+safe (structural, never animation-dependent), and print-safe (a print override in
+`responsive.css` renders the numbering in ink and tightens the margin). On mobile
+(≤ 600px) the number column collapses to a thin accent tick to reclaim width.
+
+## Information architecture
+
+- **Primary view:** a single, generously-margined readable column — the monograph
+  page — with the index-rail in the reserved left margin and content to its right.
+- **Central object:** the candidate (Anthony) — hero name + headline + one-line
+  summary, presented as the title page / colophon of the monograph.
+- **Primary action:** Contact / open a GitHub issue — the one accent-filled CTA;
+  CV print/download stays a quiet secondary.
+- **Density:** comfortable-but-information-dense — generous vertical rhythm and
+  margin, but each entry is compact and metadata-rich (mono dates, tech tags,
+  numbers) so a skimming reader extracts signal fast.
+- **Why this serves the job (not a generic stat-cards + table shell):** a technical
+  decision-maker decides in under a minute whether this is a senior systems
+  engineer worth talking to. The logbook spine, ruled grid, and mono data voice
+  signal "a precise engineer made this" before a word is read; the numbered entries
+  let a skimmer jump and the typeset measure rewards a closer read — authority by
+  documentation, not by decoration.

--- a/app/DESIGN.md
+++ b/app/DESIGN.md
@@ -31,15 +31,15 @@ semantic one. Every other stylesheet reads these custom properties unchanged.
 
 **Palette**
 
-| Token | Dark | Light |
-|---|---|---|
-| `--bg` | `#0e0e10` (graphite page) | `#fafafa` (paper) |
-| `--surface` | `#18181b` | `#ffffff` |
-| `--fg` | `#fafafa` | `#0e0e10` |
-| `--muted` | `#a1a1aa` | `#52525b` |
-| `--border` | `#2e2e33` | `#d4d4d8` |
-| `--accent` | `#3bd6c6` (signal teal) | `#0e7c70` (deep teal) |
-| `--accent-ink` | `#0e0e10` | `#ffffff` |
+| Token          | Dark                      | Light                 |
+| -------------- | ------------------------- | --------------------- |
+| `--bg`         | `#0e0e10` (graphite page) | `#fafafa` (paper)     |
+| `--surface`    | `#18181b`                 | `#ffffff`             |
+| `--fg`         | `#fafafa`                 | `#0e0e10`             |
+| `--muted`      | `#a1a1aa`                 | `#52525b`             |
+| `--border`     | `#2e2e33`                 | `#d4d4d8`             |
+| `--accent`     | `#3bd6c6` (signal teal)   | `#0e7c70` (deep teal) |
+| `--accent-ink` | `#0e0e10`                 | `#ffffff`             |
 
 **Shape & depth:** squarer/flatter — `--radius-sm 4px` / `--radius-md 6px` /
 `--radius-lg 8px`, `9999px` only for true circles; `--border-weight 1px` hairlines
@@ -53,12 +53,12 @@ reference-manual serif), body **Inter** (`--font-body`/`--font-sans`), data
 
 **AA contrast ratios (verified):**
 
-| Pair | Dark | Light |
-|---|---|---|
-| `--fg` on `--bg` | 18.48:1 | 18.48:1 |
-| `--muted` on `--bg` | 7.52:1 | 7.41:1 |
-| `--accent-ink` on `--accent` fill | 10.67:1 | 5.08:1 |
-| `--accent` as text on `--bg` | 10.67:1 | 4.86:1 |
+| Pair                              | Dark    | Light   |
+| --------------------------------- | ------- | ------- |
+| `--fg` on `--bg`                  | 18.48:1 | 18.48:1 |
+| `--muted` on `--bg`               | 7.52:1  | 7.41:1  |
+| `--accent-ink` on `--accent` fill | 10.67:1 | 5.08:1  |
+| `--accent` as text on `--bg`      | 10.67:1 | 4.86:1  |
 
 All ≥ 4.5:1 (normal text). The demo banner (`--accent-ink` on `--warning`) is
 11.55:1 dark / 5.02:1 light. The terminal easter-egg keeps authentic ANSI colours

--- a/app/index.html
+++ b/app/index.html
@@ -28,8 +28,8 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <!-- Editorial persona — Fraunces (serif display) + Inter (body) + JetBrains Mono -->
-    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
+    <!-- Logbook brand — Spectral (serif display) + Inter (body) + JetBrains Mono (data) -->
+    <link href="https://fonts.googleapis.com/css2?family=Spectral:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet" />
     <script>
       (function () {
         var t = localStorage.getItem('theme');

--- a/app/index.html
+++ b/app/index.html
@@ -1,5 +1,6 @@
 <!doctype html>
-<html lang="fr" data-persona="editorial">
+<!-- Logbook brand theme (engineering logbook / technical monograph) — see app/DESIGN.md -->
+<html lang="fr">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/app/src/components/ui/DemoBanner.tsx
+++ b/app/src/components/ui/DemoBanner.tsx
@@ -10,10 +10,11 @@ const bannerStyle: CSSProperties = {
   padding: '0.4rem 1.25rem',
   fontSize: '0.85rem',
   fontWeight: 500,
-  // Amber on near-black — contrast ratio > 7:1 (WCAG 2.1 AA, even AAA).
-  color: '#451a03',
-  background: '#fbbf24',
-  borderBottom: '1px solid #b45309',
+  // Semantic warning fill (amber, tracks the theme) with graphite ink on top.
+  // --warning is #fbbf24 (dark) / #b45309 (light); graphite ink keeps >7:1 AA.
+  color: 'var(--accent-ink)',
+  background: 'var(--warning)',
+  borderBottom: '1px solid color-mix(in srgb, var(--warning) 70%, #000)',
   textAlign: 'center',
 };
 

--- a/app/src/styles/contract.css
+++ b/app/src/styles/contract.css
@@ -45,7 +45,9 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *, *::before, *::after {
+  *,
+  *::before,
+  *::after {
     animation-duration: 0.001ms !important;
     transition-duration: 0.001ms !important;
   }

--- a/app/src/styles/contract.css
+++ b/app/src/styles/contract.css
@@ -1,0 +1,52 @@
+/*
+ * chrysa Design System — CONTRACT (shared by every app, do not edit per-app).
+ * Spec: chrysa/shared-standards/docs/DESIGN-SYSTEM.md
+ * Vendored from shared-standards/templates/contract.css (PR #143, pending merge).
+ *
+ * Declares the semantic token NAMES (the registry) with neutral fallback values,
+ * plus the a11y floor. This app overrides the VALUES in tokens.css. Names fixed.
+ */
+
+:root {
+  --bg: #0e0e10;
+  --surface: #18181b;
+  --surface-2: #242428;
+  --fg: #fafafa;
+  --muted: #a1a1aa;
+  --border: #2e2e33;
+  --accent: #c8ff00;
+  --accent-ink: #0e0e10;
+  --signal: #22c55e;
+  --warning: #fbbf24;
+  --danger: #ff4d4d;
+  --ring: var(--accent);
+  --radius: 6px;
+  --border-weight: 1px;
+  --shadow: 0 1px 3px rgb(0 0 0 / 0.24);
+  --font-display: system-ui, sans-serif;
+  --font-body: system-ui, -apple-system, sans-serif;
+  --font-mono: ui-monospace, monospace;
+  --density: 2.5rem;
+  --motion: 160ms;
+}
+
+:root.light {
+  --bg: #fafafa;
+  --surface: #ffffff;
+  --surface-2: #f0f0f0;
+  --fg: #0e0e10;
+  --muted: #52525b;
+  --border: #d4d4d8;
+  --accent: #a3e000;
+  --accent-ink: #0e0e10;
+  --signal: #15803d;
+  --warning: #b45309;
+  --danger: #dc2626;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/app/src/styles/responsive.css
+++ b/app/src/styles/responsive.css
@@ -107,4 +107,20 @@
     padding: 2rem 0;
     break-inside: avoid;
   }
+  /* Index-rail: keep the logbook numbering (it belongs on the printed page),
+     but render it in ink and tighten the reserved margin for print width. */
+  main > .section > .container {
+    padding-left: 3rem;
+  }
+  main > .section > .container::before {
+    left: 2.25rem;
+    background: #000;
+  }
+  main > .section > .container::after {
+    width: 2.25rem;
+    color: #000;
+  }
+  main > .section > .container .section__label::before {
+    background: #000;
+  }
 }

--- a/app/src/styles/sections.css
+++ b/app/src/styles/sections.css
@@ -1,3 +1,101 @@
+/* ─── Index-rail / logbook spine (signature element) ─────────────────────── */
+/* A monospaced spine in the reserved left margin of each numbered section:    */
+/* zero-padded entry numbers ([01] [02] …), a baseline tick, and a            */
+/* terminal-prompt section marker (▸ §). Pure CSS — counters + pseudo-elements */
+/* so it survives reduced-motion and print, no JS or markup churn.            */
+
+/* Number the sections of the main monograph column. */
+main {
+  counter-reset: logbook;
+}
+
+/* Reserve the left measure for the spine and create the positioning context.
+   Scoped to sections INSIDE main so the footer/navbar containers are spared. */
+main > .section {
+  counter-increment: logbook;
+}
+main > .section > .container {
+  position: relative;
+  padding-left: calc(var(--space-xl) + var(--rail-width));
+}
+
+/* The spine: a 1px structural hairline running the height of each section,
+   sitting at the inner edge of the reserved margin. */
+main > .section > .container::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: var(--rail-width);
+  width: var(--border-weight);
+  background: var(--rail-tick);
+  pointer-events: none;
+}
+
+/* The logbook entry head: zero-padded number + terminal-prompt marker,
+   rendered in the reserved margin, aligned to the section's first line. */
+main > .section > .container::after {
+  content: '[' counter(logbook, decimal-leading-zero) ']' '\A' var(--rail-prompt-glyph);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: var(--rail-width);
+  padding-right: var(--space-sm);
+  white-space: pre; /* honour the \A line break */
+  text-align: right;
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  line-height: 1.5;
+  letter-spacing: 0.02em;
+  color: var(--rail-num);
+  pointer-events: none;
+  user-select: none;
+}
+
+/* Tint only the prompt glyph line is not possible from one pseudo-element;
+   instead the whole head reads muted and the prompt marker earns the accent
+   via a second tick at the spine head — a precise registration mark. */
+main > .section > .container .section__label {
+  position: relative;
+}
+main > .section > .container .section__label::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: calc(-1 * var(--space-xl) - var(--border-weight));
+  width: var(--space-md);
+  height: var(--border-weight);
+  background: var(--rail-prompt);
+  transform: translateY(-50%);
+}
+
+/* Mobile: the reserved margin is too costly on narrow screens — collapse the
+   rail to a thin accent tick and drop the number column. */
+@media (max-width: 600px) {
+  main > .section > .container {
+    padding-left: var(--space-lg);
+  }
+  main > .section > .container::after {
+    display: none;
+  }
+  main > .section > .container::before {
+    left: 0;
+  }
+  main > .section > .container .section__label::before {
+    left: calc(-1 * var(--space-lg));
+    width: var(--space-sm);
+  }
+}
+
+/* Reduced motion: the rail is structural (drawn, not animated) — nothing to do
+   beyond the global guards, but make the intent explicit. */
+@media (prefers-reduced-motion: reduce) {
+  main > .section > .container::after,
+  main > .section > .container::before {
+    transition: none;
+  }
+}
+
 /* ─── Navbar ────────────────────────────────────────────────────────────── */
 .navbar {
   position: fixed;

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -1,51 +1,72 @@
-/* ─── Design Tokens — Editorial persona (warm amber accent) ──────────────── */
-/* Canonical contract: chrysa/shared-standards/docs/DESIGN-SYSTEM.md (§1 Editorial) */
-/* Persona: Editorial — serif display, comfortable density, soft depth, 10px radius. */
-/* Per-app accent: warm amber — dark #f0a830 / light #b45309 (used sparingly:      */
-/* links + one CTA, never large acid blocks).                                      */
+/* ─── Design Tokens — Logbook brand theme (signal-teal accent) ───────────── */
+/* Brand: "Engineering logbook / technical monograph" — precise, crafted,     */
+/* quiet authority. See app/BRAND-BRIEF.md and app/DESIGN.md.                  */
+/*                                                                            */
+/* Architecture: this file is the single source of brand VALUES.             */
+/*   1. import contract.css — the shared SEMANTIC token registry (--bg, --fg, */
+/*      --accent, --radius, --font-display … fixed names the audit checks).   */
+/*   2. assign the brand values to those semantic names (dark + light).       */
+/*   3. alias the app's local --clr-*/component token names to the semantic   */
+/*      ones, so existing components inherit the brand with zero churn.       */
 
-/* Dark theme (default) — html also carries data-persona="editorial" */
+@import './contract.css';
+
+/* ─── Dark theme (default) ────────────────────────────────────────────────── */
 :root,
 [data-theme='dark'] {
-  /* Surfaces (shared neutral frame) */
-  --clr-bg: #0e0e10;
-  --clr-bg-2: #18181b;
-  --clr-bg-card: #18181b;
-  --clr-bg-card-hover: #242428;
-
-  /* Borders — hairline (Editorial 1px, neutral; NOT a loud FG border) */
-  --clr-border: #2e2e33;
-  --clr-border-hover: var(--clr-accent-1);
+  /* ── Semantic contract values (brand) ── */
+  --bg: #0e0e10; /* graphite page — never warm */
+  --surface: #18181b;
+  --surface-2: #242428;
+  --fg: #fafafa; /* 18.48:1 on --bg */
+  --muted: #a1a1aa; /* 7.52:1 on --bg */
+  --border: #2e2e33; /* structural hairline (the rule grid) */
+  --accent: #3bd6c6; /* signal teal — instrument-readout hue */
+  --accent-ink: #0e0e10; /* graphite ink on a teal fill — 10.67:1 */
+  --signal: #22c55e;
+  --warning: #fbbf24;
+  --danger: #ff4d4d;
+  --ring: var(--accent);
+  /* Squarer/flatter — drafted, not pillowy */
+  --radius: 6px;
   --border-weight: 1px;
+  /* Near-flat depth: a hairline edge, not a soft glow */
+  --shadow: 0 1px 0 rgb(0 0 0 / 0.4);
+  /* Typeset monograph: Spectral display + Inter body + JetBrains Mono data */
+  --font-display: 'Spectral', 'Newsreader', Georgia, serif;
+  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  /* App-local alias: existing components reference --font-sans */
+  --font-sans: var(--font-body);
+  --density: 2.5rem;
+  --motion: 180ms; /* calm: short, ease-out, no spring */
 
-  /* Warm amber accent — restrained (links / one CTA) */
-  --clr-accent-1: #f0a830;
-  --clr-accent-2: #d98e1f;
+  /* ── App-local aliases → semantic tokens (no component churn) ── */
+  --clr-bg: var(--bg);
+  --clr-bg-2: var(--surface);
+  --clr-bg-card: var(--surface);
+  --clr-bg-card-hover: var(--surface-2);
 
-  /* Accent helpers (names kept; no gradients in Editorial) */
-  --gradient: var(--clr-accent-1);
-  --gradient-text: var(--clr-accent-1);
+  --clr-border: var(--border);
+  --clr-border-hover: var(--accent);
 
-  /* Text */
-  --clr-text: #fafafa;
-  --clr-text-2: #a1a1aa;
+  --clr-accent-1: var(--accent);
+  --clr-accent-2: var(--accent);
+
+  /* No gradients in the logbook brand — solid signal-teal */
+  --gradient: var(--accent);
+  --gradient-text: var(--accent);
+
+  --clr-text: var(--fg);
+  --clr-text-2: var(--muted);
   --clr-text-3: #71717a;
 
-  /* Accent-text: amber, for links/inline emphasis (8:1 on --clr-bg) */
-  --clr-accent-text: var(--clr-accent-1);
-
-  /* Ink on an amber fill (the one CTA) */
-  --accent-ink: #0e0e10;
-
-  /* Typography — serif display + sans body (Editorial) */
-  --font-display: 'Fraunces', 'Newsreader', Georgia, serif;
-  --font-sans: 'Inter', system-ui, -apple-system, sans-serif;
-  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+  --clr-accent-text: var(--accent);
 
   /* A11y offset */
   --a11y-font-offset: 0px;
 
-  /* Spacing (4/8pt scale; Editorial breathes — generous section rhythm) */
+  /* Spacing (4/8pt scale; the page breathes like a typeset book) */
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
   --space-md: 1rem;
@@ -53,57 +74,62 @@
   --space-xl: 2.5rem;
   --space-2xl: 5rem;
 
-  /* Radius — Editorial: soft 10px scale; 9999px for genuine circles */
-  --radius-sm: 8px;
-  --radius-md: 10px;
-  --radius-lg: 14px;
+  /* Radius — tight, ruled scale (sm 4 / md 6 / lg 8); full only for circles */
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
   --radius-full: 9999px;
 
-  /* Shadows — soft blurred elevation (no hard offset, no glow) */
-  --shadow-card: 0 4px 24px rgb(0 0 0 / 0.18);
-  --shadow-glow: 0 4px 24px rgb(0 0 0 / 0.18);
+  /* Shadows — near-flat: hairline edge only, depth comes from the rules */
+  --shadow-card: var(--shadow);
+  --shadow-glow: var(--shadow);
 
-  /* Transitions — calm (Editorial motion 220ms) */
-  --transition: 0.22s ease;
+  /* Transition — calm, linear/ease-out, no bounce */
+  --transition: var(--motion) ease-out;
 
   /* Layout */
   --max-width: 1100px;
   --section-py: 6rem;
+
+  /* ── Index-rail / logbook spine (signature element) ── */
+  --rail-width: 3.25rem; /* reserved left measure for the spine */
+  --rail-tick: var(--border); /* baseline tick colour */
+  --rail-num: var(--muted); /* zero-padded entry numbers */
+  --rail-prompt: var(--accent); /* terminal-prompt section marker (▸ §) */
+  --rail-prompt-glyph: '\25B8\00A0\00A7'; /* ▸ § */
 }
 
-/* Light theme */
+/* ─── Light theme ─────────────────────────────────────────────────────────── */
 [data-theme='light'] {
-  --clr-bg: #fafafa;
-  --clr-bg-2: #f0f0f0;
-  --clr-bg-card: #ffffff;
-  --clr-bg-card-hover: #f0f0f0;
+  --bg: #fafafa; /* paper */
+  --surface: #ffffff;
+  --surface-2: #f0f0f0;
+  --fg: #0e0e10; /* 18.48:1 on --bg */
+  --muted: #52525b; /* 7.41:1 on --bg */
+  --border: #d4d4d8;
+  --accent: #0e7c70; /* darker teal for contrast on paper */
+  --accent-ink: #ffffff; /* white ink on teal fill — 5.08:1 */
+  --signal: #15803d;
+  --warning: #b45309;
+  --danger: #dc2626;
+  --shadow: 0 1px 0 rgb(0 0 0 / 0.12);
 
-  /* Borders — light hairline */
-  --clr-border: #d4d4d8;
-  --clr-border-hover: var(--clr-accent-1);
-
-  /* Warm amber — darker variant for contrast on light */
-  --clr-accent-1: #b45309;
-  --clr-accent-2: #92400e;
-
-  --gradient: var(--clr-accent-1);
-  --gradient-text: var(--clr-accent-1);
-
-  --clr-text: #0e0e10;
-  --clr-text-2: #52525b;
+  /* Local aliases follow the semantic values automatically, except the few
+     that need a light-specific literal. */
   --clr-text-3: #71717a;
-
-  --clr-accent-text: var(--clr-accent-1);
-
-  --accent-ink: #ffffff;
-
-  --shadow-card: 0 4px 24px rgb(0 0 0 / 0.1);
-  --shadow-glow: 0 4px 24px rgb(0 0 0 / 0.1);
+  --shadow-card: var(--shadow);
+  --shadow-glow: var(--shadow);
 }
 
 /* ─── A11y dataset overrides ─────────────────────────────────────────────── */
 
 [data-high-contrast='true'] {
+  --bg: #000000;
+  --surface: #0a0a0a;
+  --surface-2: #111111;
+  --fg: #ffffff;
+  --muted: #dddddd;
+  --border: #ffffff;
   --clr-bg: #000000;
   --clr-bg-2: #0a0a0a;
   --clr-bg-card: #111111;
@@ -115,7 +141,7 @@
 }
 
 [data-dyslexia='true'] {
-  --font-sans: 'OpenDyslexic', 'Comic Sans MS', cursive, sans-serif;
+  --font-body: 'OpenDyslexic', 'Comic Sans MS', cursive, sans-serif;
 }
 
 [data-reduced-motion='true'] *,

--- a/app/src/styles/tokens.css
+++ b/app/src/styles/tokens.css
@@ -6,8 +6,8 @@
 /*   1. import contract.css — the shared SEMANTIC token registry (--bg, --fg, */
 /*      --accent, --radius, --font-display … fixed names the audit checks).   */
 /*   2. assign the brand values to those semantic names (dark + light).       */
-/*   3. alias the app's local --clr-*/component token names to the semantic   */
-/*      ones, so existing components inherit the brand with zero churn.       */
+/*   3. alias the app's local --clr-* and component token names to the         */
+/*      semantic ones, so existing components inherit the brand, no churn.     */
 
 @import './contract.css';
 


### PR DESCRIPTION
## Why

Pilot for the brand-themes design system (shared-standards ADR 0003 / PR #143). Proves a per-app **brand brief** yields a deliberate, memorable identity instead of a generic genre persona. linkendin-resume was the worst "Editorial persona" clash; it now wears a brand derived from its own job.

> Brand direction is a **proposal** (`app/BRAND-BRIEF.md`) — open to redirection by the owner.

## Brand concept — "Engineering logbook / technical monograph"

- **Mood:** precise / crafted / quiet-authority.
- **Type:** display **Spectral** (replaces Fraunces) · body Inter · data JetBrains Mono.
- **Accent:** warm amber → **signal teal** `#3bd6c6` (dark) / `#0e7c70` (light) — instrument-readout hue.
- **Shape:** squarer/flatter (4–8px radius, hairline rules, near-flat shadow).
- **Signature element:** a monospaced **index-rail / logbook spine** down the left margin — zero-padded entry numbers `[01]`, baseline ticks, `▸ §` section markers. Pure CSS (counters + `::before`/`::after`), reduced-motion- and print-safe.

## How it conforms to the contract

- Vendored `app/src/styles/contract.css` (shared semantic token registry — PR #143 not yet merged, vendored for now).
- `tokens.css` imports it, defines all **20 semantic token names** with brand values (dark+light), and aliases the app's local `--clr-*` names to them → **zero component churn**.
- `data-persona="editorial"` removed from `index.html`.
- `app/DESIGN.md` rewritten to brand-theme format; `app/BRAND-BRIEF.md` added.

## Verification

- **WCAG AA both themes:** fg/bg 18.48:1 · muted/bg 7.5:1 · accent-ink/accent-fill 10.67:1 (dark) / 5.08:1 (light) — all ≥4.5:1.
- **Tests:** 120 passed (13 files), vitest in node:22 container.
- **Build:** `tsc && vite build` green.
- **Conformance:** all 20 tokens defined, contract imported, no persona, DESIGN.md + BRAND-BRIEF.md present (verified manually; `audit-design-conformance.sh` passes under GNU grep / CI).

## Note

Visual review recommended (dark + light) — screenshots not captured in this headless run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)