### PR TITLE
feat(design): surface skill proficiency in print (IA pass)

### DIFF
--- a/app/DESIGN.md
+++ b/app/DESIGN.md
@@ -91,6 +91,10 @@ safe (structural, never animation-dependent), and print-safe (a print override i
 - **Density:** comfortable-but-information-dense — generous vertical rhythm and
   margin, but each entry is compact and metadata-rich (mono dates, tech tags,
   numbers) so a skimming reader extracts signal fast.
+- **Print fidelity:** the printed/PDF CV is a first-class surface (recruiters read it
+  offline). Skill proficiency is encoded as dots + a hover tooltip on screen; on paper
+  there is no hover, so print inks the active dots (signal-teal washes out in grayscale)
+  and reveals the tier word inline (`.skill-pill__level-print`). No screen change.
 - **Why this serves the job (not a generic stat-cards + table shell):** a technical
   decision-maker decides in under a minute whether this is a senior systems
   engineer worth talking to. The logbook spine, ruled grid, and mono data voice

--- a/app/src/components/cv/SkillsCloud.tsx
+++ b/app/src/components/cv/SkillsCloud.tsx
@@ -33,6 +33,12 @@ function SkillPill({ skill, lang }: { skill: Skill; lang: string }) {
           <span key={d} className={'skill-pill__dot' + (d <= skill.level ? ' skill-pill__dot--active' : '')} />
         ))}
       </div>
+      {/* Print-only proficiency tier: the screen reveals it on hover, but a printed/PDF
+          CV has no hover — surface the tier word there. aria-hidden: the <li> aria-label
+          already announces it, this span only restores the visual label on paper. */}
+      <span className="skill-pill__level-print" aria-hidden="true">
+        {levels[skill.level]}
+      </span>
       <AnimatePresence>
         {hovered && (
           <motion.div

--- a/app/src/styles/responsive.css
+++ b/app/src/styles/responsive.css
@@ -107,6 +107,20 @@
     padding: 2rem 0;
     break-inside: avoid;
   }
+  /* Skill proficiency on paper: ink the active dots (signal-teal washes out in
+     grayscale) and reveal the tier word the hover-tooltip would otherwise hide. */
+  .skill-pill__dot--active {
+    background: #000 !important;
+    border-color: #000 !important;
+  }
+  .skill-pill__level-print {
+    display: block;
+    margin-top: 2px;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.04em;
+    color: #000;
+  }
   /* Index-rail: keep the logbook numbering (it belongs on the printed page),
      but render it in ink and tighten the reserved margin for print width. */
   main > .section > .container {

--- a/app/src/styles/sections.css
+++ b/app/src/styles/sections.css
@@ -528,6 +528,11 @@ main > .section > .container .section__label::before {
 .skill-pill__name {
   color: var(--clr-text);
 }
+/* Proficiency tier word — hidden on screen (dots + hover tooltip carry it there),
+   revealed only in print where there is no hover (see responsive.css print block). */
+.skill-pill__level-print {
+  display: none;
+}
 /* Editorial skill level tooltip: soft pill, amber text on surface */
 .skill-pill__level {
   position: absolute;


### PR DESCRIPTION
## Context — design-campaign Phase-4 IA pass

linkendin-resume is the React app at the tail of the Phase-4 IA campaign. Unlike
the earlier repos (devtool/container-webview/discordium), its IA is **already
document-appropriate**: a monograph/logbook layout (not a stat-cards reflex),
projects already render `url`/`stars` conditionally, skills carry dots + a
context-rich hover tooltip, and `DESIGN.md` already documents the IA. The
brand-theme pass (#226) gave it identity. So there is no Inspector to build here.

One genuine on-doctrine gap remained — *surface data the source has but a
consumed surface hides*:

- `cv.json` grades **every** skill 1-5.
- On screen that grade reads via dots + a **hover** tooltip (the tier word).
- On the **printed / PDF CV** — a first-class recruiter surface — there is no
  hover, so the tier word disappeared entirely and the signal-teal active dots
  washed out in grayscale.

## Change

- New print-only tier label `.skill-pill__level-print` (one `<span>`, `display:none`
  on screen, revealed in the `@media print` block).
- Ink the active dots in print so the 1-5 ratio stays crisp in grayscale.
- `DESIGN.md`: documented the print-fidelity rule under Information Architecture.

Screen rendering is unchanged. The `<li>` `aria-label` already announces the tier
to screen readers, so the new span is `aria-hidden` (no double announcement).
No backend, no new deps, no component churn beyond the one span. +29 lines.

## Verification (Docker, per repo convention)

- `make typecheck` → ✓ Passed
- `make lint` → ✓ clean
- `make test` → ✓ 120/120 (13 files), incl. SkillsCloud render test

🤖 Generated with [Claude Code](https://claude.com/claude-code)